### PR TITLE
feat(ci): publish Docker images to Docker Hub and add Docker badges

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main, master]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        run: |
+          sha=$(echo "${{ github.sha }}" | cut -c1-12)
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            echo "backend_tags=earthcake/cakecake-backend:${{ github.ref_name }},earthcake/cakecake-backend:latest" >> "$GITHUB_OUTPUT"
+            echo "web_tags=earthcake/cakecake-web:${{ github.ref_name }},earthcake/cakecake-web:latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "backend_tags=earthcake/cakecake-backend:sha-$sha,earthcake/cakecake-backend:latest" >> "$GITHUB_OUTPUT"
+            echo "web_tags=earthcake/cakecake-web:sha-$sha,earthcake/cakecake-web:latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.backend_tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push web image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ./cakecake-vue/cakecake-web/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.web_tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   <a href="https://b23.tv/9VnJIWm">
     <img src="https://img.shields.io/badge/演示视频-B站-00a1d6?style=flat-square&logo=bilibili" alt="演示视频">
   </a>
+  <img src="https://img.shields.io/badge/Docker%20Compose-ready-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker Compose">
   <a href="https://github.com/earthcake2233/cakecake">
     <img src="https://img.shields.io/github/stars/earthcake2233/cakecake?style=flat-square&logo=github" alt="Stars">
   </a>
@@ -38,6 +39,9 @@
   <a href="https://codecov.io/gh/earthcake2233/cakecake"><img src="https://img.shields.io/codecov/c/github/earthcake2233/cakecake?flag=frontend&style=flat-square&logo=codecov&logoColor=white&label=Vue%20Coverage" alt="Vue Coverage"></a>
   <a href="https://codecov.io/gh/earthcake2233/cakecake"><img src="https://img.shields.io/codecov/c/github/earthcake2233/cakecake?flag=backend&style=flat-square&logo=codecov&logoColor=white&label=Go%20Coverage" alt="Go Coverage"></a>
   <img src="https://img.shields.io/github/commit-activity/m/earthcake2233/cakecake?style=flat-square&logo=github" alt="Commit activity">
+  <a href="https://hub.docker.com/r/earthcake/cakecake-backend">
+    <img src="https://img.shields.io/docker/image-size/earthcake/cakecake-backend?style=flat-square&logo=docker&logoColor=white&label=Image%20Size" alt="Docker Image Size">
+  </a>
 </p>
 
 ---
@@ -51,7 +55,7 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
-启动完成后访问 **http://localhost:8888**。首次启动自动完成数据库迁移、Elasticsearch 索引与演示数据初始化，无需本地安装 Go / Node / MySQL / Redis / RabbitMQ / Elasticsearch / FFmpeg。
+启动完成后访问 **[http://localhost:8888](http://localhost:8888)**。首次启动自动完成数据库迁移、Elasticsearch 索引与演示数据初始化，无需本地安装 Go / Node / MySQL / Redis / RabbitMQ / Elasticsearch / FFmpeg。
 
 端口映射、演示账号、AI 助手与 OSS 上传的开启方式及故障排查，见 [deploy/DEPLOY.md · 本地一键体验](./deploy/DEPLOY.md#〇本地一键体验docker-compose)。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -26,6 +26,7 @@ Versioned DB migrations, global rate limiting, graceful shutdown, observability,
   <a href="https://b23.tv/9VnJIWm">
     <img src="https://img.shields.io/badge/Demo%20Video-Bilibili-00a1d6?style=flat-square&logo=bilibili" alt="Demo Video">
   </a>
+  <img src="https://img.shields.io/badge/Docker%20Compose-ready-2496ED?style=flat-square&logo=docker&logoColor=white" alt="Docker Compose">
   <a href="https://github.com/earthcake2233/cakecake">
     <img src="https://img.shields.io/github/stars/earthcake2233/cakecake?style=flat-square&logo=github" alt="Stars">
   </a>
@@ -38,6 +39,9 @@ Versioned DB migrations, global rate limiting, graceful shutdown, observability,
   <a href="https://codecov.io/gh/earthcake2233/cakecake"><img src="https://img.shields.io/codecov/c/github/earthcake2233/cakecake?flag=frontend&style=flat-square&logo=codecov&logoColor=white&label=Vue%20Coverage" alt="Vue Coverage"></a>
   <a href="https://codecov.io/gh/earthcake2233/cakecake"><img src="https://img.shields.io/codecov/c/github/earthcake2233/cakecake?flag=backend&style=flat-square&logo=codecov&logoColor=white&label=Go%20Coverage" alt="Go Coverage"></a>
   <img src="https://img.shields.io/github/commit-activity/m/earthcake2233/cakecake?style=flat-square&logo=github" alt="Commit activity">
+  <a href="https://hub.docker.com/r/earthcake/cakecake-backend">
+    <img src="https://img.shields.io/docker/image-size/earthcake/cakecake-backend?style=flat-square&logo=docker&logoColor=white&label=Image%20Size" alt="Docker Image Size">
+  </a>
 </p>
 
 ---
@@ -51,7 +55,7 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
-Open **http://localhost:8888**. First boot runs DB migration, Elasticsearch indexing, and demo-data seeding automatically — no local Go / Node / MySQL / Redis / RabbitMQ / Elasticsearch / FFmpeg installation needed.
+Open **[http://localhost:8888](http://localhost:8888)**. First boot runs DB migration, Elasticsearch indexing, and demo-data seeding automatically — no local Go / Node / MySQL / Redis / RabbitMQ / Elasticsearch / FFmpeg installation needed.
 
 Ports, demo accounts, enabling the AI assistant / OSS uploads, and troubleshooting live in [deploy/DEPLOY.md · Local One-Command Experience](./deploy/DEPLOY.md#0-local-one-command-experience-docker-compose).
 

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -42,7 +42,7 @@ cp .env.example .env          # 可选：不复制也能用默认值
 docker compose up -d --build
 ```
 
-打开 **http://localhost:8888**。首次启动自动完成：GORM AutoMigrate 建表 → `SEED_DEMO_DATA=true` 写入演示用户 / 视频 / 弹幕 → ES 全量索引。
+打开 **[http://localhost:8888](http://localhost:8888)**。首次启动自动完成：GORM AutoMigrate 建表 → `SEED_DEMO_DATA=true` 写入演示用户 / 视频 / 弹幕 → ES 全量索引。
 
 ### 端口与账号
 

--- a/deploy/DEPLOY_EN.md
+++ b/deploy/DEPLOY_EN.md
@@ -42,7 +42,7 @@ cp .env.example .env          # optional; defaults work without it
 docker compose up -d --build
 ```
 
-Open **http://localhost:8888**. On first boot: GORM AutoMigrate creates the schema → `SEED_DEMO_DATA=true` writes demo users / videos / danmaku → ES is fully reindexed.
+Open **[http://localhost:8888](http://localhost:8888)**. On first boot: GORM AutoMigrate creates the schema → `SEED_DEMO_DATA=true` writes demo users / videos / danmaku → ES is fully reindexed.
 
 ### Ports & Accounts
 


### PR DESCRIPTION
- add docker-publish workflow: buildx + login + build-push, latest & sha tags on main, version tags on v* tags
- images: earthcake/cakecake-backend, earthcake/cakecake-web
- add Docker Compose / Image Size badges to README (CN/EN), keep the compose badge up front
- fix docs: render localhost URL bold as explicit link

Docs-checked: README.md README_EN.md deploy/DEPLOY.md deploy/DEPLOY_EN.md