### PR TITLE
feat(ci): image-first compose with one-command quickstart and OSS upl…

### DIFF
--- a/.github/workflows/compose-check.yml
+++ b/.github/workflows/compose-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - "docker-compose.yml"
+      - "docker-compose.dev.yml"
       - ".env.example"
       - "deploy/env.production.example"
       - "Dockerfile"
@@ -20,6 +21,7 @@ on:
     branches: [main, master]
     paths:
       - "docker-compose.yml"
+      - "docker-compose.dev.yml"
       - ".env.example"
       - "deploy/env.production.example"
       - "Dockerfile"
@@ -50,6 +52,9 @@ jobs:
       - name: Validate compose file
         run: docker compose config --quiet
 
+      - name: Validate dev compose override
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet
+
       - name: Env drift check (.env.example <-> compose)
         run: python3 scripts/check_compose_env.py
 
@@ -75,7 +80,7 @@ jobs:
           RABBITMQ_PORT: 15672
           RABBITMQ_MGMT_PORT: 15673
           ES_PORT: 19200
-        run: docker compose up -d --build
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
 
       - name: Wait for frontend to serve
         run: |
@@ -110,7 +115,7 @@ jobs:
       - name: Scan backend image (Trivy)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: cakecake-backend:latest
+          image-ref: earthcake/cakecake-backend:latest
           format: sarif
           output: trivy-backend.sarif
           severity: HIGH,CRITICAL
@@ -118,7 +123,7 @@ jobs:
       - name: Scan web image (Trivy)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: cakecake-web:latest
+          image-ref: earthcake/cakecake-web:latest
           format: sarif
           output: trivy-web.sarif
           severity: HIGH,CRITICAL

--- a/README.md
+++ b/README.md
@@ -46,18 +46,24 @@
 
 ---
 
-## Docker Compose 快速启动
+## Docker 一键启动
 
-前置要求：Docker Engine（含 Compose v2），建议内存 ≥ 4 GB（Elasticsearch 占用较高）。
+仅需 Docker（Compose v2，建议内存 ≥ 4 GB），无需本地 Go / Node 环境，一条命令启动 MySQL/Redis/RabbitMQ/ES + 前后端：
 
 ```bash
-cp .env.example .env
-docker compose up -d --build
+curl -fsSL https://raw.githubusercontent.com/earthcake2233/cakecake/main/scripts/quickstart.sh | bash
 ```
 
-启动完成后访问 **[http://localhost:8888](http://localhost:8888)**。首次启动自动完成数据库迁移、Elasticsearch 索引与演示数据初始化，无需本地安装 Go / Node / MySQL / Redis / RabbitMQ / Elasticsearch / FFmpeg。
+或手动执行（Windows 原生终端走此路径）：
 
-端口映射、演示账号、AI 助手与 OSS 上传的开启方式及故障排查，见 [deploy/DEPLOY.md · 本地一键体验](./deploy/DEPLOY.md#〇本地一键体验docker-compose)。
+```bash
+git clone --depth 1 git@github.com:earthcake2233/cakecake.git
+cd cakecake
+cp .env.example .env
+docker compose up -d
+```
+
+启动后访问 **[http://localhost:8888](http://localhost:8888)**。首次启动自动完成数据库迁移、ES 索引与演示数据初始化；端口、账号与扩展配置见 [deploy/DEPLOY.md · 本地一键体验](./deploy/DEPLOY.md#〇本地一键体验docker-compose)。
 
 ---
 
@@ -142,8 +148,6 @@ npm run dev                   # http://localhost:8888
 | [deploy/DEPLOY.md](./deploy/DEPLOY.md)                                       | 运维                   | 生产部署（Nginx、systemd、OSS、ES）       |
 | [docs/manual-video-ingest.md](./docs/manual-video-ingest.md)                 | 运维                   | 关闭网页上传时，本地 OSS + 手动写库发视频 |
 | [docs/ai-gateway.md](./docs/ai-gateway.md)                                   | 运维                   | AI 助手（DeepSeek）配置                   |
-| [.github/workflows/deploy.yml](./.github/workflows/deploy.yml)               | 运维                   | 可选：GitHub Actions 构建并 SSH 部署      |
-| [.github/workflows/compose-check.yml](./.github/workflows/compose-check.yml) | 运维                   | compose 环境变量漂移检查 + 语法校验 + 冒烟测试 |
 | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)                               | 全栈 / 面试            | 系统架构、核心模块设计、关键决策          |
 | [docs/ARCHITECTURE_EN.md](./docs/ARCHITECTURE_EN.md)                         | Full-stack / Interview | Architecture (English)                    |
 | [SPEC.md](./SPEC.md)                                                         | 开发                   | 功能与验收规格                            |
@@ -156,8 +160,10 @@ npm run dev                   # http://localhost:8888
 
 ```
 cakecake/
-├── Dockerfile              # 后端镜像（含 FFmpeg）
-├── docker-compose.yml      # 一键启动：MySQL/Redis/RabbitMQ/ES + 前后端
+├── Dockerfile               # 后端镜像（含 FFmpeg）
+├── docker-compose.yml       # 一键启动（默认拉 Docker Hub 发布镜像）
+├── docker-compose.dev.yml   # 开发者本地构建 override
+├── scripts/quickstart.sh    # 一键启动脚本（curl | bash）
 ├── cmd/cakecake/            # Go 入口
 ├── internal/                # handler / service / worker / ws 等
 ├── configs/                 # sensitive_words.txt、ip2region_v4.xdb
@@ -178,7 +184,7 @@ cakecake/
 | ---------------------------------- | ------------------------------------------------------------------------------------- |
 | **Go** 1.22+（`go.mod` 当前 1.25） | 后端                                                                                  |
 | **Node.js** + **npm**              | 前端（请用 npm，勿与 yarn 混用锁文件）                                                |
-| **Docker**（可选）                 | 一条命令启动完整前后端（见上方 Compose 快速开始）                                     |
+| **Docker**（可选）                 | 一条命令启动完整前后端（见上方 Docker 一键启动）                                       |
 | **MySQL**                          | 持久化                                                                                |
 | **Redis**                          | 播放计数、弹幕冷却、Refresh Token 等                                                  |
 | **RabbitMQ**                       | 转码队列（规格要求，不可用 Redis List 替代）                                          |

--- a/README_EN.md
+++ b/README_EN.md
@@ -46,18 +46,24 @@ Versioned DB migrations, global rate limiting, graceful shutdown, observability,
 
 ---
 
-## Docker Compose Quick Start
+## Docker One-Command Startup
 
-Prerequisites: Docker Engine with Compose v2; ≥ 4 GB RAM recommended (Elasticsearch is memory-hungry).
+Docker with Compose v2 is all you need (≥ 4 GB RAM recommended); no local Go/Node toolchain. One command starts MySQL/Redis/RabbitMQ/ES + backend + frontend:
 
 ```bash
-cp .env.example .env
-docker compose up -d --build
+curl -fsSL https://raw.githubusercontent.com/earthcake2233/cakecake/main/scripts/quickstart.sh | bash
 ```
 
-Open **[http://localhost:8888](http://localhost:8888)**. First boot runs DB migration, Elasticsearch indexing, and demo-data seeding automatically — no local Go / Node / MySQL / Redis / RabbitMQ / Elasticsearch / FFmpeg installation needed.
+Or manually (use this path on native Windows terminals):
 
-Ports, demo accounts, enabling the AI assistant / OSS uploads, and troubleshooting live in [deploy/DEPLOY.md · Local One-Command Experience](./deploy/DEPLOY.md#0-local-one-command-experience-docker-compose).
+```bash
+git clone --depth 1 git@github.com:earthcake2233/cakecake.git
+cd cakecake
+cp .env.example .env
+docker compose up -d
+```
+
+Open **[http://localhost:8888](http://localhost:8888)**. First boot runs DB migration, ES indexing, and demo-data seeding automatically; ports, accounts, and extension setup live in [deploy/DEPLOY_EN.md · Local One-Command Experience](./deploy/DEPLOY_EN.md#0-local-one-command-experience-docker-compose).
 
 ---
 
@@ -142,8 +148,6 @@ Frontend details and env vars: **[cakecake-vue/cakecake-web/README.md](./cakecak
 | [deploy/DEPLOY.md](./deploy/DEPLOY.md)                                        | Ops                     | Production deploy (Nginx, systemd, OSS, ES) |
 | [docs/manual-video-ingest.md](./docs/manual-video-ingest.md)                  | Ops                     | Local OSS + manual DB insert when web upload is disabled |
 | [docs/ai-gateway.md](./docs/ai-gateway.md)                                    | Ops                     | AI assistant (DeepSeek) config           |
-| [.github/workflows/deploy.yml](./.github/workflows/deploy.yml)                | Ops                     | Optional GitHub Actions build & SSH deploy |
-| [.github/workflows/compose-check.yml](./.github/workflows/compose-check.yml)  | Ops                     | Compose env-drift check + config validation + smoke test |
 | [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)                                | Full-stack / Interview  | Architecture, core modules, decisions    |
 | [docs/ARCHITECTURE_EN.md](./docs/ARCHITECTURE_EN.md)                          | Full-stack / Interview  | Architecture (English)                   |
 | [SPEC.md](./SPEC.md)                                                          | Developer               | Functional & acceptance spec             |
@@ -156,8 +160,10 @@ Frontend details and env vars: **[cakecake-vue/cakecake-web/README.md](./cakecak
 
 ```
 cakecake/
-├── Dockerfile              # Backend image (includes FFmpeg)
-├── docker-compose.yml      # One-command stack: MySQL/Redis/RabbitMQ/ES + frontend/backend
+├── Dockerfile               # Backend image (includes FFmpeg)
+├── docker-compose.yml       # One-command stack (pulls published Docker Hub images by default)
+├── docker-compose.dev.yml   # Dev override to build from source
+├── scripts/quickstart.sh    # One-command launcher (curl | bash)
 ├── cmd/cakecake/            # Go entrypoint
 ├── internal/                # handler / service / worker / ws etc.
 ├── configs/                 # sensitive_words.txt, ip2region_v4.xdb
@@ -178,7 +184,7 @@ cakecake/
 | ---------------------------------- | ------------------------------------------------------------------------------------- |
 | **Go** 1.22+ (`go.mod` is 1.25)    | Backend                                                                               |
 | **Node.js** + **npm**              | Frontend (use npm; do not mix yarn lockfiles)                                         |
-| **Docker** (optional)              | One-command full-stack startup (see Compose quick start above)                        |
+| **Docker** (optional)              | One-command full-stack startup (see Docker One-Command Startup above)                  |
 | **MySQL**                          | Persistence                                                                           |
 | **Redis**                          | Play counts, danmaku cooldown, refresh tokens, etc.                                   |
 | **RabbitMQ**                       | Transcode queue (required by spec; Redis List is not a substitute)                    |

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -39,8 +39,10 @@
 ```bash
 cd <仓库根目录>
 cp .env.example .env          # 可选：不复制也能用默认值
-docker compose up -d --build
+docker compose up -d
 ```
+
+compose 默认从 Docker Hub 拉取已发布的镜像（`earthcake/cakecake-backend:latest` / `earthcake/cakecake-web:latest`），无需本地构建；想从源码构建时改用 `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build`。
 
 打开 **[http://localhost:8888](http://localhost:8888)**。首次启动自动完成：GORM AutoMigrate 建表 → `SEED_DEMO_DATA=true` 写入演示用户 / 视频 / 弹幕 → ES 全量索引。
 
@@ -57,8 +59,36 @@ docker compose up -d --build
 ### 可选增强
 
 - **AI 助手（DeepSeek Function Calling）**：`.env` 填入 `DEEPSEEK_API_KEY`，执行 `docker compose up -d backend` 重启后端；
-- **网页上传 + 异步转码**：`.env` 填入 `OSS_*` 凭证，并把 `VIDEO_UPLOAD_DISABLED=false`、`VITE_VIDEO_UPLOAD_DISABLED=false`（前端编译期开关），然后 `docker compose up -d --build web backend` 重建前端并重启后端；
+- **网页上传 + 异步转码**：按下方「开启网页上传」四步操作。**注意：Docker Hub 发布镜像的前端开关已编译为关闭，只用发布镜像（`docker compose up -d` 拉取的镜像）无法开启上传，必须本地重建前端镜像。**
 - **停止 / 重置**：`docker compose down`；彻底重置（删除数据卷）用 `docker compose down -v`。
+
+#### 开启网页上传（需要阿里云 OSS）
+
+默认"演示模式"不上传（前端入口隐藏、后端无 OSS）。按下面四步开启：
+
+① `.env` 填入阿里云 OSS 凭证（5 个变量）：
+
+```bash
+OSS_ACCESS_KEY_ID=xxx
+OSS_ACCESS_KEY_SECRET=xxx
+OSS_BUCKET=xxx
+OSS_ENDPOINT=oss-cn-hangzhou.aliyuncs.com
+OSS_PUBLIC_URL_PREFIX=https://xxx.oss-cn-hangzhou.aliyuncs.com
+```
+
+② `.env` 打开前端编译期开关：
+
+```bash
+VITE_VIDEO_UPLOAD_DISABLED=false
+```
+
+③ 重建前端镜像并重启后端（**关键：发布镜像里前端开关已编译成 true，只改 `.env` 不生效**）：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build web backend
+```
+
+④ 打开 http://localhost:8888，创作中心出现上传入口；上传 → RabbitMQ 异步转码 → 封面截帧全链路可用。
 
 ### 与生产部署的差异
 
@@ -67,6 +97,8 @@ compose 面向**本地一键体验**：上传默认禁用（与线上 Demo 行�
 ### CI 守护
 
 `.github/workflows/compose-check.yml` 对 compose 做三重守护：环境变量漂移检查（`.env.example` ↔ compose）、`docker compose config` 语法校验、全栈冒烟测试（真实构建镜像并验证健康检查与种子数据）。代码演进导致 compose 失效时，CI 会直接报红。
+
+镜像发布由 `.github/workflows/docker-publish.yml` 负责：main 合并 / `v*` tag 时自动构建并推送 Docker Hub（`latest` + `sha-<前12位>`，tag 事件额外推 `vX.Y.Z`）。
 
 ---
 

--- a/deploy/DEPLOY_EN.md
+++ b/deploy/DEPLOY_EN.md
@@ -39,8 +39,10 @@ To see the project running in 30 seconds, skip the full production setup for now
 ```bash
 cd <repo root>
 cp .env.example .env          # optional; defaults work without it
-docker compose up -d --build
+docker compose up -d
 ```
+
+The compose file pulls the published images from Docker Hub by default (`earthcake/cakecake-backend:latest` / `earthcake/cakecake-web:latest`) — no local build required; to build from source, use `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build` instead.
 
 Open **[http://localhost:8888](http://localhost:8888)**. On first boot: GORM AutoMigrate creates the schema → `SEED_DEMO_DATA=true` writes demo users / videos / danmaku → ES is fully reindexed.
 
@@ -57,8 +59,36 @@ Open **[http://localhost:8888](http://localhost:8888)**. On first boot: GORM Aut
 ### Optional Upgrades
 
 - **AI assistant (DeepSeek Function Calling)**: put `DEEPSEEK_API_KEY` in `.env`, then `docker compose up -d backend`;
-- **Web upload + async transcoding**: put `OSS_*` credentials in `.env`, set `VIDEO_UPLOAD_DISABLED=false` and `VITE_VIDEO_UPLOAD_DISABLED=false` (frontend build-time flag), then `docker compose up -d --build web backend`;
+- **Web upload + async transcoding**: follow the four steps in "Enabling Web Upload" below. **Note: the published Docker Hub images have the frontend flag baked to `true`, so uploads cannot be enabled with the published images alone — you must rebuild the frontend locally.**
 - **Stop / reset**: `docker compose down`; full reset (removes volumes) with `docker compose down -v`.
+
+#### Enabling Web Upload (Alibaba Cloud OSS)
+
+The default "demo mode" does not upload (frontend entry hidden, backend has no OSS). Enable it in four steps:
+
+1. Put the Alibaba Cloud OSS credentials in `.env` (5 variables):
+
+```bash
+OSS_ACCESS_KEY_ID=xxx
+OSS_ACCESS_KEY_SECRET=xxx
+OSS_BUCKET=xxx
+OSS_ENDPOINT=oss-cn-hangzhou.aliyuncs.com
+OSS_PUBLIC_URL_PREFIX=https://xxx.oss-cn-hangzhou.aliyuncs.com
+```
+
+2. Turn on the frontend build-time flag in `.env`:
+
+```bash
+VITE_VIDEO_UPLOAD_DISABLED=false
+```
+
+3. Rebuild the frontend image and restart the backend (**key: the published image has the flag baked to `true`, so editing `.env` alone has no effect**):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build web backend
+```
+
+4. Open http://localhost:8888 — the upload entry appears in the creator center; upload → RabbitMQ async transcoding → cover thumbnail generation all work.
 
 ### Differences from Production
 
@@ -67,6 +97,8 @@ Compose targets the **local one-command experience**: upload is disabled by defa
 ### CI Guard
 
 `.github/workflows/compose-check.yml` triple-guards the stack: env-drift checks (`.env.example` ↔ compose), `docker compose config` validation, and a full-stack smoke test (real image builds, health checks, seed data). If code evolution breaks the one-command experience, CI fails loudly.
+
+Image publishing is handled by `.github/workflows/docker-publish.yml`: on main merges / `v*` tags it builds and pushes to Docker Hub (`latest` + `sha-<first 12>`, plus `vX.Y.Z` on tag events).
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,18 @@
+# Dev override: build backend/web images from local source instead of pulling
+# the published Docker Hub images. Requires a full repo checkout.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  web:
+    build:
+      context: .
+      dockerfile: cakecake-vue/cakecake-web/Dockerfile
+      args:
+        VITE_VIDEO_UPLOAD_DISABLED: ${VITE_VIDEO_UPLOAD_DISABLED:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@
 #
 # Usage:
 #   cp .env.example .env            # optional; defaults work without it
-#   docker compose up -d --build    # builds & starts MySQL/Redis/RabbitMQ/ES + backend + frontend
+#   docker compose up -d            # pulls published images & starts MySQL/Redis/RabbitMQ/ES + backend + frontend
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build  # build from source
 #   open http://localhost:8888
 #
 # Maintenance contract (guarded by CI .github/workflows/compose-check.yml):
@@ -90,9 +91,7 @@ services:
       start_period: 60s
 
   backend:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: earthcake/cakecake-backend:latest
     container_name: cakecake-backend
     restart: unless-stopped
     depends_on:
@@ -165,11 +164,7 @@ services:
       start_period: 30s
 
   web:
-    build:
-      context: .
-      dockerfile: cakecake-vue/cakecake-web/Dockerfile
-      args:
-        VITE_VIDEO_UPLOAD_DISABLED: ${VITE_VIDEO_UPLOAD_DISABLED:-true}
+    image: earthcake/cakecake-web:latest
     container_name: cakecake-web
     restart: unless-stopped
     depends_on:

--- a/docs/manual-video-ingest.md
+++ b/docs/manual-video-ingest.md
@@ -144,6 +144,32 @@ VITE_VIDEO_UPLOAD_DISABLED=false
 
 本地开发 `.env.local` 不设或设为 `false`，本机仍可正常走上传接口联调。
 
+Docker Compose 环境（发布镜像 + dev override 重建）：
+
+```bash
+# .env 设 VITE_VIDEO_UPLOAD_DISABLED=false，然后
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build web backend
+```
+
+注意：Docker Hub 发布镜像的前端开关已编译为关闭，必须本地重建前端镜像才能生效；完整步骤见 [deploy/DEPLOY.md](../deploy/DEPLOY.md)。
+
+---
+
+## 7. Docker Compose 环境
+
+compose 演示模式同样默认关闭上传，手动发视频流程与上面完全一致（本机转码 → OSS → 写库），区别只在执行 SQL 的位置：
+
+- 数据库在 `cakecake-mysql` 容器内；先确认栈已启动：`docker compose ps`
+- 进入 MySQL 执行与第 2 / 3 / 4 节相同的 SQL：
+
+```bash
+docker compose exec mysql mysql -uroot -p cakecake
+# 密码：.env 的 MYSQL_ROOT_PASSWORD（默认 cakecake_dev）；库名：MYSQL_DATABASE（默认 cakecake）
+```
+
+- 查 user_id、插入语句与第 2 / 3 / 4 节完全相同；`user_id` 可直接用演示账号（如 `暗猫の祝福`）
+- 插入后访问 `http://localhost:8888/#/video/BV{id}`；compose 已配 ES 时，`docker compose restart backend` 会触发索引
+
 ---
 
 ## 相关文件

--- a/docs/manual-video-ingest_EN.md
+++ b/docs/manual-video-ingest_EN.md
@@ -144,6 +144,32 @@ Then `npm run build` and upload `dist/`.
 
 Local dev `.env.local` can keep unset or `false` for normal upload endpoint debugging.
 
+For Docker Compose (published images + dev override rebuild):
+
+```bash
+# set VITE_VIDEO_UPLOAD_DISABLED=false in .env, then
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build web backend
+```
+
+Note: the published Docker Hub images have the frontend flag baked to `true` — a local frontend rebuild is required for this to take effect; full steps live in [deploy/DEPLOY_EN.md](../deploy/DEPLOY_EN.md).
+
+---
+
+## 7. Docker Compose Environments
+
+The compose demo mode also disables upload by default; manual ingest is identical (transcode locally → OSS → insert into DB) — only where you run the SQL differs:
+
+- The database runs in the `cakecake-mysql` container; make sure the stack is up: `docker compose ps`
+- Open the MySQL shell and run the same SQL as sections 2 / 3 / 4:
+
+```bash
+docker compose exec mysql mysql -uroot -p cakecake
+# Password: MYSQL_ROOT_PASSWORD from .env (default cakecake_dev); database: MYSQL_DATABASE (default cakecake)
+```
+
+- Finding user_id and the INSERT statements are exactly the same as sections 2 / 3 / 4; `user_id` can be one of the demo accounts (e.g., `暗猫の祝福`)
+- After inserting, open `http://localhost:8888/#/video/BV{id}`; with ES enabled in compose, `docker compose restart backend` triggers indexing
+
 ---
 
 ## Related Files

--- a/scripts/quickstart.sh
+++ b/scripts/quickstart.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# cakecake one-command quickstart.
+#
+# Downloads the official compose file and .env defaults from the cakecake
+# repository, then starts the full stack with the published Docker Hub images
+# (MySQL/Redis/RabbitMQ/ES + backend + frontend). No source clone or local
+# build required. Idempotent: existing docker-compose.yml / .env are kept.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/earthcake2233/cakecake/main/scripts/quickstart.sh | bash
+
+set -euo pipefail
+
+REPO_RAW="https://raw.githubusercontent.com/earthcake2233/cakecake/main"
+
+say() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v docker >/dev/null 2>&1 || die "docker not found. Install Docker first: https://docs.docker.com/get-docker/"
+docker compose version >/dev/null 2>&1 || die "docker compose plugin not found (Docker Desktop 4.x+ / Compose v2 required)"
+
+if [ ! -f docker-compose.yml ]; then
+  say "Downloading docker-compose.yml"
+  curl -fsSL "$REPO_RAW/docker-compose.yml" -o docker-compose.yml
+else
+  say "docker-compose.yml already exists, keeping it"
+fi
+
+if [ ! -f .env ]; then
+  say "Creating .env from .env.example"
+  curl -fsSL "$REPO_RAW/.env.example" -o .env.example
+  cp .env.example .env
+else
+  say ".env already exists, keeping it"
+fi
+
+say "Pulling images (first run may take a while)"
+docker compose pull
+
+say "Starting cakecake"
+docker compose up -d
+
+cat <<'EOF'
+
+cakecake is starting:
+  Web       http://localhost:8888
+  API       http://localhost:8080   (health: /api/v1/health)
+  Swagger   http://localhost:8080/swagger/
+
+Demo users (password: demo123456):
+  暗猫の祝福 / 加载超时请稍后 / Baka恶魔 / 三栗lili / Yeuoly / 科学超电磁炮F / 泛式大大
+
+Admin console: http://localhost:8888/#/admin/login  (admin / change-me-admin)
+
+Stop:   docker compose down
+Reset:  docker compose down -v
+Update: re-run this script
+EOF


### PR DESCRIPTION
…oad docs

- docker-compose.yml: backend/web use published Docker Hub images (earthcake/*)
- add docker-compose.dev.yml: build-from-source override
- add scripts/quickstart.sh: one-command launcher (download compose/.env, pull, up)
- compose-check: validate dev override, smoke via override, Trivy scans published image names
- README (CN/EN): Docker One-Command Startup dual track, badge reorder, docs table md-only, aligned tree
- DEPLOY (CN/EN): published-image notes, docker-publish workflow, four-step OSS upload enablement
- docs/manual-video-ingest (CN/EN): Docker Compose section and compose rebuild path

Docs-checked: README.md README_EN.md deploy/DEPLOY.md deploy/DEPLOY_EN.md docs/manual-video-ingest.md docs/manual-video-ingest_EN.md