### PR TITLE
fix: seed agent welcome message when resetting AI chat history

### DIFF
--- a/internal/client/Agent.go
+++ b/internal/client/Agent.go
@@ -33,6 +33,7 @@ type Agent interface {
 	PostAssistantMessage(conv *dm.DmConversation, humanID uint64, content string, extra ...string) (*dm.DmMessage, error)
 	ProfileCount(ctx context.Context) (int64, error)
 	ReloadProfiles()
+	ResetConversation(ctx context.Context, conv *dm.DmConversation, humanID uint64) (*dm.DmMessage, error)
 	RenameAgentProfileSlug(ctx context.Context, p *agent.AgentProfile, newSlug string) error
 	SyncAgentProfile(ctx context.Context, p *agent.AgentProfile) error
 	UnmarshalWelcomeList(raw json.RawMessage, fallback []string) ([]string, error)

--- a/internal/handler/direct_message.go
+++ b/internal/handler/direct_message.go
@@ -313,7 +313,7 @@ func (a *API) DeleteDmConversation(c *gin.Context) {
 // @Success      200 {object} map[string]interface{}
 // @Router       /dm/conversations/{id}/reset [post]
 func (a *API) ResetDmAgentConversation(c *gin.Context) {
-	_, ok := middleware.UserID(c)
+	uid, ok := middleware.UserID(c)
 	if !ok {
 		resp.Err(c, http.StatusUnauthorized, errcode.CodeUnauthorized)
 		return
@@ -323,11 +323,38 @@ func (a *API) ResetDmAgentConversation(c *gin.Context) {
 		resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
 		return
 	}
-	if err := a.DmSvc.ResetConversationForAgent(c.Request.Context(), convID); err != nil {
+	ctx := c.Request.Context()
+	conv, err := a.DmSvc.GetConversationByID(ctx, convID)
+	if err != nil {
+		resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
+		return
+	}
+	if _, err := a.DmSvc.GetParticipant(ctx, convID, uid); err != nil {
+		resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
+		return
+	}
+
+	// Agent conversations restart with a fresh welcome message; other threads
+	// keep the legacy clear-history behavior.
+	var welcome *dmMessageDTO
+	if a.dmIsAgentConv(conv) && a.Agent != nil {
+		msg, err := a.Agent.ResetConversation(ctx, conv, uid)
+		if err != nil {
+			resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
+			return
+		}
+		senderName, senderAvatar := a.dmUserBrief(ctx, msg.SenderID)
+		dto := a.dmFormatMessage(msg, senderName, senderAvatar)
+		welcome = &dto
+	} else if err := a.DmSvc.ResetConversationForAgent(ctx, convID); err != nil {
 		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
 		return
 	}
-	resp.OK(c, okResponse{OK: true})
+	part, _ := a.DmSvc.GetParticipant(ctx, convID, uid)
+	resp.OK(c, gin.H{
+		"conversation":    a.dmFormatConversation(ctx, conv, uid, part),
+		"welcome_message": welcome,
+	})
 }
 
 // PatchDmConversationSettings updates pin / mute for the current user's participant row.

--- a/internal/handler/integration_agent_dm_reset_test.go
+++ b/internal/handler/integration_agent_dm_reset_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package handler
+
+import (
+	"cakecake/internal/model/agent"
+	"cakecake/internal/model/dm"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResetDmAgentConversation_Welcome verifies that clearing an agent
+// conversation deletes history, writes a fresh welcome message, resets unread,
+// and returns {conversation, welcome_message} per the frontend contract.
+func TestResetDmAgentConversation_Welcome(t *testing.T) {
+	api, r, _ := newTestAPI(t)
+
+	// Seed bot user + agent profile.
+	bot := seedUser(t, api, "agent_bot_reset", "AI助手", 0)
+	prof := agent.AgentProfile{
+		Slug: "reset_test", BotUserID: bot.ID, DisplayName: "AI助手",
+		Enabled: true, WelcomeMessagesJSON: `["你好，欢迎回来"]`,
+	}
+	require.NoError(t, api.DB.Create(&prof).Error)
+
+	// Human user + agent conversation with unread and one history message.
+	u := seedUser(t, api, "reset_human", "人类", 0)
+	tk := tok(t, api, u.ID)
+	conv := dm.DmConversation{Kind: dm.DmKindAgent, UserLow: u.ID, UserHigh: bot.ID, AgentProfileID: prof.ID}
+	require.NoError(t, api.DB.Create(&conv).Error)
+	require.NoError(t, api.DB.Create(&dm.DmParticipant{ConversationID: conv.ID, UserID: u.ID, UnreadCount: 3}).Error)
+	require.NoError(t, api.DB.Create(&dm.DmParticipant{ConversationID: conv.ID, UserID: bot.ID}).Error)
+	require.NoError(t, api.DB.Create(&dm.DmMessage{ConversationID: conv.ID, SenderID: u.ID, Role: "user", Content: "旧消息"}).Error)
+
+	// Reset.
+	w := doJSON(r, "POST", fmt.Sprintf("/api/v1/dm/conversations/%d/reset", conv.ID), tk, nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var body struct {
+		Data struct {
+			Conversation dmConversationDTO `json:"conversation"`
+			Welcome      *dmMessageDTO     `json:"welcome_message"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotNil(t, body.Data.Welcome, "agent reset should return a welcome message")
+	require.Equal(t, "assistant", body.Data.Welcome.Role)
+	require.Equal(t, "你好，欢迎回来", body.Data.Welcome.Content)
+	require.Equal(t, conv.ID, body.Data.Conversation.ID)
+	require.Zero(t, body.Data.Conversation.UnreadCount)
+
+	// History is replaced by exactly the welcome message.
+	var n int64
+	require.NoError(t, api.DB.Model(&dm.DmMessage{}).Where("conversation_id = ?", conv.ID).Count(&n).Error)
+	require.Equal(t, int64(1), n)
+	var part dm.DmParticipant
+	require.NoError(t, api.DB.Where("conversation_id = ? AND user_id = ?", conv.ID, u.ID).First(&part).Error)
+	require.Zero(t, part.UnreadCount)
+}
+
+// TestResetDmAgentConversation_NonAgent keeps the legacy clear-history behavior
+// for human conversations and returns a null welcome_message.
+func TestResetDmAgentConversation_NonAgent(t *testing.T) {
+	api, r, _ := newTestAPI(t)
+	u1 := seedUser(t, api, "reset_u1", "甲", 0)
+	u2 := seedUser(t, api, "reset_u2", "乙", 0)
+	tk := tok(t, api, u1.ID)
+	conv := dm.DmConversation{Kind: dm.DmKindHuman, UserLow: u1.ID, UserHigh: u2.ID}
+	require.NoError(t, api.DB.Create(&conv).Error)
+	require.NoError(t, api.DB.Create(&dm.DmParticipant{ConversationID: conv.ID, UserID: u1.ID}).Error)
+	require.NoError(t, api.DB.Create(&dm.DmParticipant{ConversationID: conv.ID, UserID: u2.ID}).Error)
+	require.NoError(t, api.DB.Create(&dm.DmMessage{ConversationID: conv.ID, SenderID: u1.ID, Role: "user", Content: "hi"}).Error)
+
+	w := doJSON(r, "POST", fmt.Sprintf("/api/v1/dm/conversations/%d/reset", conv.ID), tk, nil)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var body struct {
+		Data struct {
+			Welcome *dmMessageDTO `json:"welcome_message"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Nil(t, body.Data.Welcome)
+	var n int64
+	require.NoError(t, api.DB.Model(&dm.DmMessage{}).Where("conversation_id = ?", conv.ID).Count(&n).Error)
+	require.Zero(t, n)
+}


### PR DESCRIPTION
- handler ResetDmAgentConversation now routes agent conversations through Agent.ResetConversation (delete history + write welcome + reset unread + clear gateway history) and returns {conversation, welcome_message} per the frontend contract; non-agent threads keep the legacy clear-history path
- client.Agent: expose ResetConversation on the handler-facing contract
- tests: cover agent welcome reset and non-agent fallback
- Docs: 无