### PR TITLE
fix(ci): upgrade appleboy/scp-action to v1.0.0 with debug logging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 # Dependency update automation (GitHub Actions, Go modules, npm).
 # Grouped so each ecosystem produces one PR per cycle instead of one per dependency;
-# high-risk major bumps for frontend tooling and the deploy scp action are ignored.
+# high-risk major bumps for frontend tooling are ignored.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -11,9 +11,6 @@ updates:
     groups:
       actions:
         patterns: ["*"]
-    ignore:
-      - dependency-name: "appleboy/scp-action"
-        versions: [">=1.0.0"]
 
   - package-ecosystem: gomod
     directory: /

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,7 +81,7 @@ jobs:
           tar czf minibili-release.tar.gz -C release .
 
       - name: Upload bundle to server
-        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
@@ -89,6 +89,7 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT || 22 }}
           source: minibili-release.tar.gz
           target: /tmp
+          debug: true
 
       - name: Install on server and restart
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5


### PR DESCRIPTION
- scp-action v0.1.7 -> v1.0.0 (SHA ff85246) to fix hang during server upload
- enable debug: true to surface the exact scp error if it still fails
- stop ignoring appleboy/scp-action >= 1.0.0 in Dependabot