### PR TITLE
feat(ai): production-grade assistant chat — single-source state, no-partial continue, model-declared cards, multi-instance support

### DIFF
--- a/cmd/cakecake/main.go
+++ b/cmd/cakecake/main.go
@@ -25,6 +25,7 @@ import (
 	"cakecake/internal/service/danmaku"
 	"cakecake/internal/service/dm"
 	"context"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
@@ -267,6 +268,17 @@ func main() {
 		ChatHub: chatHub, Log: log, RC: runtimeCfg,
 		ToolExec: &toolkit.PlatformExecutor{DB: db, ES: esc, Sens: sens},
 	}
+	// Cross-instance agent transport: events (deltas/tool frames/messages) are
+	// fanned out via Redis Pub/Sub so the user's WebSocket is reachable from
+	// any replica; control commands are routed to the generation owner.
+	agentRelay := agent.NewAgentRelay(rdb, chatHub, log, agentSvc)
+	agentSvc.Relay = agentRelay
+	agentSvc.InstanceID = fmt.Sprintf("instance-%d", os.Getpid())
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		agentRelay.RunSubscriber(ctx)
+	}()
 
 	userProv := service.NewUserProvider(db)
 	videoProv := video.NewVideoProvider(db)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -222,10 +222,34 @@ flowchart LR
 
 ### 6. AI 助手（DeepSeek）
 
-- 封装 OpenAI 兼容客户端（`internal/aigateway/deepseek.go`）
-- 用户发起私信对话；管理员后台配置 Agent 角色（名称、头像、系统提示词）
-- 消息携带对话历史作为上下文，Agent 回复插入同一对话线程
-- Temperature: 0.7，超时: 90s，未启用流式（私信场景更简单可靠）
+- OpenAI 兼容客户端（`internal/aigateway/deepseek.go`），默认模型 `deepseek-v4-flash`
+- 用户与 Agent 角色私信对话；**流式打字机** + 停止/继续/重新生成 + 追问建议 + 工具调用（站内搜索/详情/榜单）
+- 结果卡片由模型在回复末尾声明（`【展示】工具名#ID`），后端精确落卡，不再用正则从回复文本猜
+- 生成状态与编排整体收在 `internal/service/agent`（handler 只转发 WS/HTTP），详见 [ai-gateway.md](ai-gateway.md)
+
+#### 6.1 多实例状态外置（水平扩展）
+
+生成状态（暂停/缓冲/代次）与 WS 连接都是进程内资源。多副本部署时，用户的 WS 可能连到副本 A、生成却跑在副本 B，因此事件面与控制面外置到 Redis：
+
+```mermaid
+graph TB
+    A["API 副本 A<br/>生成 owner · AgentService"]
+    B["API 副本 B<br/>用户 WS · ChatHub"]
+    EV[("Redis<br/>agent:event 频道")]
+    CT[("Redis<br/>agent:control 频道")]
+    SNAP[("Redis<br/>mb:agent:gen:{uid} 快照")]
+
+    A -->|delta · 工具帧 · dm_message| EV
+    EV --> B
+    B -->|agent_cancel / agent_continue| CT
+    CT --> A
+    A <-->|owner / genID / pending| SNAP
+    B -.->|ResumeReply 读快照判断 owner| SNAP
+```
+
+- **事件面**：delta/工具帧/建议/dm 消息发布到 `agent:event`，每个副本的订阅器写入本地 `ChatHub`——用户 WS 落在哪个副本都能收到。
+- **控制面**：暂停/继续/取代发布到 `agent:control`，只有快照 owner 生效（`from` 字段忽略自我广播）；快照带 genID 守卫，旧代次不会误删新快照。
+- **性能**：热路径缓冲/回放仍在 owner 内存；owner 宕机时暂停完成的回复可从快照 pending 恢复。
 
 ---
 
@@ -247,6 +271,7 @@ flowchart LR
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | **v1 用单体而非微服务**                               | 单人开发，快速迭代。代码按领域分层（`handler/`、`service/`、`worker/`），为后续拆分为 Kratos 微服务预留空间                     |
 | **Redis Pub/Sub 做弹幕广播中继，而非 WebSocket 直发** | 解耦广播与 HTTP handler。多副本订阅同一 Redis 频道，无需共享内存即可水平扩展                                                    |
+| **AI 事件/控制走 Redis Pub/Sub + 生成快照（owner/genID 守卫）** | 多副本下 WS 与生成解耦：事件扇出到用户所在副本，暂停/继续路由到 owner；热路径缓冲留在 owner 内存保证性能                     |
 | **转码用 RabbitMQ 而非 Redis List**                   | RabbitMQ 提供消息持久化、消费确认、死信队列——视频处理不可接受数据丢失                                                           |
 | **GORM AutoMigrate + goose 版本化迁移**                | 开发环境 GORM AutoMigrate 自动建表（V1-V19），生产环境 APP_ENV=production 默认走 goose SQL 迁移（V20+），支持 up/down 回滚 |      |
 | **ES 可选而非强制依赖**                               | 降低上手门槛，未配置时搜索页优雅降级                                                                                            |

--- a/docs/ARCHITECTURE_EN.md
+++ b/docs/ARCHITECTURE_EN.md
@@ -222,10 +222,34 @@ flowchart LR
 
 ### 6. AI Assistant (DeepSeek)
 
-- OpenAI-compatible client in `internal/aigateway/deepseek.go`
-- Users start DM conversations; admin configures agent profiles (name, avatar, system prompt)
-- Messages carry conversation history as context, agent replies inserted into the same thread
-- Temperature: 0.7, timeout: 90s, streaming: disabled (simpler for DM use case)
+- OpenAI-compatible client in `internal/aigateway/deepseek.go`, default model `deepseek-v4-flash`
+- Users chat with agent profiles via DM; **streaming typewriter** + pause/continue/regenerate + follow-up suggestions + tool calls (site search / detail / trending)
+- Result cards are declared by the model at the end of the reply (`【展示】tool#ID`); the backend persists exactly those instead of guessing from the reply text
+- Generation state and orchestration live in `internal/service/agent` (the handler only forwards WS/HTTP); see [ai-gateway_EN.md](ai-gateway_EN.md)
+
+#### 6.1 Multi-Instance State Externalization (Horizontal Scaling)
+
+Generation state (pause/buffer/generation id) and WebSocket connections are per-process resources. With multiple replicas, the user's WS may land on replica A while the generation runs on replica B — so the event plane and the control plane are externalized to Redis:
+
+```mermaid
+graph TB
+    A["API Replica A<br/>generation owner · AgentService"]
+    B["API Replica B<br/>user WS · ChatHub"]
+    EV[("Redis<br/>agent:event channel")]
+    CT[("Redis<br/>agent:control channel")]
+    SNAP[("Redis<br/>mb:agent:gen:{uid} snapshot")]
+
+    A -->|delta · tool frames · dm_message| EV
+    EV --> B
+    B -->|agent_cancel / agent_continue| CT
+    CT --> A
+    A <-->|owner / genID / pending| SNAP
+    B -.->|ResumeReply reads snapshot to find owner| SNAP
+```
+
+- **Event plane**: deltas/tool frames/suggestions/dm messages are published to `agent:event`; every replica's subscriber writes them to its local `ChatHub`, so the user receives them no matter which replica holds the WS.
+- **Control plane**: pause/continue/supersede are published to `agent:control` and only the snapshot owner applies them (`from` ignores self-published controls); snapshots are genID-guarded so a stale generation cannot clear a newer one.
+- **Performance**: the hot-path buffer/replay stays in the owner's memory; if the owner dies, a paused-completed reply can still be recovered from the snapshot's pending field.
 
 ---
 
@@ -247,6 +271,7 @@ flowchart LR
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Monolith over microservices (v1)**            | Single developer, faster iteration. Code is organized by domain (`handler/`, `service/`, `worker/`) to enable future split into Kratos microservices. |
 | **Redis Pub/Sub over direct WebSocket fan-out** | Decouples broadcast from the HTTP handler. Multiple replicas subscribe to the same Redis channel, enabling horizontal scaling without shared memory.  |
+| **AI events/controls via Redis Pub/Sub + generation snapshot (owner/genID-guarded)** | Decouples WS from generation under multiple replicas: events fan out to the replica holding the user's WS, pause/resume route to the owner; the hot-path buffer stays in the owner's memory for performance. |
 | **RabbitMQ over Redis List for transcode**      | RabbitMQ provides message persistence, consumer acknowledgments, and dead-lettering — critical for video processing where data loss is unacceptable.  |
 | **GORM AutoMigrate + goose versioned migrations** | Dev: GORM AutoMigrate (V1-V19). Prod (APP_ENV=production): goose SQL migrations (V20+) with up/down rollback. |                                                    |
 | **ES optional, not mandatory**                  | Reduces onboarding friction. The search page degrades gracefully when ES is not configured.                                                           |

--- a/docs/ai-gateway.md
+++ b/docs/ai-gateway.md
@@ -25,9 +25,35 @@ sequenceDiagram
     V->>Go: POST .../dm/.../messages
     Go->>Go: 鉴权、落库、WS 推送用户消息
     Go-->>AI: goroutine → DeepSeek 流式请求
-    AI-->>WS: 流式 delta（agent_delta）→ PushJSON
-    AI-->>WS: 最终回复落库 → dm_message
+    AI-->>WS: 流式 delta / 工具帧 / dm_message → AgentRelay
 ```
+
+单实例下 `AgentRelay` 直接写入本地 `ChatHub`；多副本部署时事件经 Redis `agent:event` 扇出到用户 WS 所在副本，控制帧经 `agent:control` 路由到生成 owner：
+
+```mermaid
+graph TB
+    A["API 副本 A<br/>生成 owner"]
+    B["API 副本 B<br/>用户 WS"]
+    EV[("Redis<br/>agent:event 频道")]
+    CT[("Redis<br/>agent:control 频道")]
+    SNAP[("Redis<br/>mb:agent:gen:{uid} 快照")]
+
+    A -->|delta · 工具帧 · dm_message| EV
+    EV --> B
+    B -->|暂停 / 继续 / 取代| CT
+    CT --> A
+    A <-->|owner / genID / pending| SNAP
+```
+
+三个 Redis 实体都在同一个 Redis 实例上，但分属三个不同的面：
+
+- **`agent:event` —— 消息面：消息往哪送。** 它承载用户 WS 收到的整条实时事件流：流式 delta、工具调用帧（start/end/result）、继续模式、追问建议、以及最终 `dm_message`/`dm_conversation`。生成 owner 发布到频道，所有副本订阅后写入各自本地 `ChatHub`——用户 WS 落在哪台副本都能收到。
+- **`agent:control` —— 控制面：命令找谁执行。** 它只搬运暂停 / 继续 / 取代三个命令。命令由用户 WS 所在副本发布（前端点停止/继续），经频道路由到生成 owner——owner 可能跑在另一台副本上。`from` 字段让发布方忽略自己的回放。
+- **`mb:agent:gen:{uid}` —— 状态面：谁在跑、跑到哪了。** 它是跨实例的紧凑快照（TTL 24h）：owner、genID、running/paused、pause_seq、conv_id、以及暂停完成但未落库的 pending 回复。任何副本读它判断"owner 是不是我"；owner 宕机时还能从 pending 恢复回复。
+
+一句话记忆：**event = 消息往哪送；control = 命令找谁执行；快照 = 谁在跑、跑到哪了。**
+
+部署拓扑与设计理由见 [ARCHITECTURE.md](ARCHITECTURE.md#61-多实例状态外置水平扩展)。
 
 ## 运营后台配置
 
@@ -222,6 +248,7 @@ AI 回复不是一次到位的，而是一小段一小段（delta）流过来的
 | 7 | re-prompt 拼接用"空白归一化最长重叠"猜接缝 | 非流式取完整续写 → 确定性规则拼缝 → 只推用户没见过的尾部 | 拼接处重复行、围栏错乱 |
 | 8 | 回复完成后同步生成追问 chips，把落库堵住 5~15s | 先落库推送，后台生成 `agent_suggestions` 后补 | 结尾死等 |
 | 9 | 推送目标默认取 `conv.UserLow`；delta 回调用全局字段 | 显式 `humanPeerForConversation`；`onDelta` 改为 per-call 闭包 | 打字机不显示、多用户串号 |
+| 10 | 生成状态与 WS 都在单实例内存，多副本部署时停止/继续路由不到 owner | Redis Pub/Sub 事件/控制双通道 + `mb:agent:gen:{uid}` 快照（owner 路由、genID 守卫）；推送统一走事件通道 | 多实例下停止/继续失效、事件丢失 |
 
 每条原则都配单测；涉及真实模型/浏览器交互的（连点停止/继续/重新生成、追问、重新生成欢迎语、榜单卡片数量），用 puppeteer + 真实模型做端到端验证。
 
@@ -248,6 +275,8 @@ AI 回复不是一次到位的，而是一小段一小段（delta）流过来的
 - `internal/aigateway/gateway.go` — per-call delta、流式工具编排
 - `internal/service/agent/agent.go` — 暂停/继续状态机、markdown 归一化
 - `internal/service/agent/agent_orchestrate.go` — 编排（run/resume/regenerate、落库、异步建议）
+- `internal/service/agent/agent_relay.go` — 跨实例事件/控制 Redis Pub/Sub
+- `internal/service/agent/agent_snapshot.go` — 跨实例生成快照（owner/genID/pending）
 - `internal/handler/agent_direct_message.go` — 只转发 WS/HTTP 触发与事件推送适配
 - `cakecake-vue/cakecake-web/src/composables/useAgentStreaming.js` — 前端流式状态机（reactive composable）
 - `cakecake-vue/cakecake-web/src/components/cakecake/MbDmMessageItem.vue` — 消息气泡/操作区/结果卡片渲染

--- a/docs/ai-gateway_EN.md
+++ b/docs/ai-gateway_EN.md
@@ -25,9 +25,35 @@ sequenceDiagram
     V->>Go: POST .../dm/.../messages
     Go->>Go: Auth, persist, WS push user message
     Go-->>AI: goroutine -> DeepSeek streaming request
-    AI-->>WS: Stream deltas (agent_delta) -> PushJSON
-    AI-->>WS: Final reply persisted -> dm_message
+    AI-->>WS: Stream deltas / tool frames / dm_message -> AgentRelay
 ```
+
+In single-instance mode `AgentRelay` writes directly to the local `ChatHub`; under multiple replicas events are fanned out through Redis `agent:event` to the replica holding the user's WS, and control frames are routed through `agent:control` to the generation owner:
+
+```mermaid
+graph TB
+    A["API Replica A<br/>generation owner"]
+    B["API Replica B<br/>user WS"]
+    EV[("Redis<br/>agent:event channel")]
+    CT[("Redis<br/>agent:control channel")]
+    SNAP[("Redis<br/>mb:agent:gen:{uid} snapshot")]
+
+    A -->|delta · tool frames · dm_message| EV
+    EV --> B
+    B -->|pause / continue / supersede| CT
+    CT --> A
+    A <-->|owner / genID / pending| SNAP
+```
+
+All three Redis entities live in the same Redis instance but belong to three different planes:
+
+- **`agent:event` — message plane: where messages go.** It carries the whole real-time event stream the user's WS receives: streaming deltas, tool frames (start/end/result), continue mode, suggestions, and the final `dm_message`/`dm_conversation`. The generation owner publishes to the channel; every replica subscribes and writes to its local `ChatHub`, so the user receives everything no matter which replica holds their WS.
+- **`agent:control` — control plane: who executes the command.** It only carries pause / continue / supersede. The replica holding the user's WS publishes the command (triggered by the frontend's stop/continue); the channel routes it to the generation owner, which may run on another replica. The `from` field makes the publisher ignore its own echoed control.
+- **`mb:agent:gen:{uid}` — state plane: who is running, where it is.** It is a compact cross-instance snapshot (TTL 24h): owner, genID, running/paused, pause_seq, conv_id, and the paused-completed reply not yet persisted (pending). Any replica reads it to decide "am I the owner"; if the owner dies, the pending reply can still be recovered.
+
+One-line memory: **event = where messages go; control = who executes the command; snapshot = who is running and where it is.**
+
+Deployment topology and rationale: [ARCHITECTURE_EN.md](ARCHITECTURE_EN.md#61-multi-instance-state-externalization-horizontal-scaling).
 
 ## Admin Configuration
 
@@ -214,6 +240,7 @@ Why it's hard: the stream is asynchronous (the backend generates while the front
 | 7 | Re-prompt stitching guessed the seam with whitespace-normalized longest overlap | Non-streaming completion → deterministic stitch rules → only the unseen tail is streamed | Duplicate lines at the seam, fence corruption |
 | 8 | Follow-up chips were generated synchronously, blocking persistence for 5–15s | Persist and push first; generate `agent_suggestions` in the background | End-of-reply dead wait |
 | 9 | Push target assumed `conv.UserLow`; the delta callback was a global field | Explicit `humanPeerForConversation`; per-call `onDelta` closures | Typewriter not showing, cross-user mixups |
+| 10 | Generation state and WebSockets lived in one instance's memory; with multiple replicas pause/resume could not reach the owner | Redis Pub/Sub event/control channels + `mb:agent:gen:{uid}` snapshot (owner routing, genID-guarded); all pushes go through the event channel | Stop/continue failing under multi-instance, events lost |
 
 Every principle has unit tests; anything involving a real model/browser (rapid stop/continue/regenerate, follow-ups, welcome regenerate, trending card counts) is verified end-to-end with puppeteer + a real model.
 
@@ -240,6 +267,8 @@ Every principle has unit tests; anything involving a real model/browser (rapid s
 - `internal/aigateway/gateway.go` — per-call deltas, streaming tool orchestration
 - `internal/service/agent/agent.go` — pause/resume state machine, markdown normalization
 - `internal/service/agent/agent_orchestrate.go` — orchestration (run/resume/regenerate, persistence, async suggestions)
+- `internal/service/agent/agent_relay.go` — cross-instance event/control Redis Pub/Sub
+- `internal/service/agent/agent_snapshot.go` — cross-instance generation snapshot (owner/genID/pending)
 - `internal/handler/agent_direct_message.go` — forwarding only (WS/HTTP triggers + push adapter)
 - `cakecake-vue/cakecake-web/src/composables/useAgentStreaming.js` — frontend streaming state machine (reactive composable)
 - `cakecake-vue/cakecake-web/src/components/cakecake/MbDmMessageItem.vue` — message bubble / actions / result cards rendering

--- a/internal/data/redis.go
+++ b/internal/data/redis.go
@@ -39,7 +39,20 @@ const (
 	SetPlayDirty         = "playcount:dirty"
 	// ChannelDanmakuFanout is Redis Pub/Sub for cross-process danmaku room fan-out (SPEC NF-3).
 	ChannelDanmakuFanout = "minibili:danmaku:fanout"
+	// ChannelAgentEvent is Redis Pub/Sub for per-user agent WebSocket events
+	// (deltas, tool frames, suggestions, dm messages) so any API replica can
+	// fan them out to the user's local ChatHub.
+	ChannelAgentEvent = "minibili:agent:event"
+	// ChannelAgentControl is Redis Pub/Sub for cross-instance agent control
+	// commands (pause/resume/supersede) routed to the generation's owner.
+	ChannelAgentControl = "minibili:agent:control"
 )
+
+// AgentGenSnapshotKey returns the Redis key holding the cross-instance
+// generation snapshot for a user.
+func AgentGenSnapshotKey(userID uint64) string {
+	return fmt.Sprintf("mb:agent:gen:%d", userID)
+}
 
 // DanmakuCooldownKey returns the Redis key for per-user danmaku cooldown.
 func DanmakuCooldownKey(userID, videoID uint64) string {

--- a/internal/handler/agent_direct_message.go
+++ b/internal/handler/agent_direct_message.go
@@ -20,30 +20,27 @@ func (a *API) ensureAgentConversationFor(uid uint64) {
 	}
 }
 
-// PushAgentMessage is the ReplyPusher adapter: formats and pushes a persisted
-// assistant message over WebSocket. The generation orchestration in the agent
-// service decides WHAT to push; this adapter decides HOW.
-func (a *API) PushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) {
-	a.dmPushAgentMessage(ctx, humanID, conv, msg)
-}
-
-// PushEvent is the ReplyPusher adapter for generic agent events (continue
-// mode, suggestions, ...).
-func (a *API) PushEvent(humanID uint64, payload map[string]interface{}) {
-	a.dmPushEvent(humanID, payload)
-}
-
-func (a *API) dmPushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) {
+// FormatAgentMessage is the ReplyPusher adapter: it formats a persisted
+// assistant message into the WebSocket payloads (dm_message + dm_conversation)
+// and returns them. The agent service is responsible for delivering the
+// payloads (locally or through the cross-instance relay), so multi-replica
+// deployments never need to know where the user's WS connection lives.
+func (a *API) FormatAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) ([]map[string]interface{}, error) {
 	if msg == nil || conv == nil {
-		return
+		return nil, nil
 	}
 	senderName, senderAvatar := a.dmUserBrief(ctx, msg.SenderID)
 	out := a.dmFormatMessage(msg, senderName, senderAvatar)
 	part, _ := a.DmSvc.GetParticipant(ctx, conv.ID, humanID)
 	convPayload := a.dmFormatConversation(ctx, conv, humanID, part)
-	event := dmMessageEvent{Type: "dm_message", Message: out}
-	if part == nil || !part.Muted {
-		a.dmPushEvent(humanID, event)
+	payloads := []map[string]interface{}{
+		{"type": "dm_message", "message": out},
+		{"type": "dm_conversation", "conversation": convPayload},
 	}
-	a.dmPushEvent(humanID, dmConversationEvent{Type: "dm_conversation", Conversation: convPayload})
+	if part != nil && part.Muted {
+		// Muted users still get the conversation update but not the message
+		// event itself (matching the previous push behavior).
+		payloads = payloads[1:]
+	}
+	return payloads, nil
 }

--- a/internal/service/agent/agent.go
+++ b/internal/service/agent/agent.go
@@ -50,6 +50,17 @@ type AgentService struct {
 	// transport seam left in the orchestration: the service decides WHAT to
 	// push, the adapter decides HOW (WebSocket formatting).
 	Pusher ReplyPusher
+	// Relay is the cross-instance Redis Pub/Sub transport for agent events and
+	// generation control commands. When nil the service falls back to pushing
+	// directly to the local ChatHub (single-process mode / unit tests).
+	Relay *AgentRelay
+	// InstanceID uniquely identifies this replica; it is stamped into the
+	// generation snapshot so pause/resume controls can be routed to the owner.
+	InstanceID string
+	// EventHook is a test/telemetry hook invoked for every published agent
+	// event after delivery. It lets unit tests observe cross-instance events
+	// without a real WebSocket connection.
+	EventHook func(uid uint64, payload map[string]interface{})
 
 	genMu     sync.Mutex
 	genStates map[uint64]*agentGenState
@@ -68,11 +79,12 @@ type DmReader interface {
 	ListMessages(ctx context.Context, convID uint64, beforeID uint64, limit int) ([]dm.DmMessage, error)
 }
 
-// ReplyPusher is the transport port for formatted agent events. Implemented by
-// the HTTP/WS adapter so the service never formats presentation DTOs.
+// ReplyPusher is the formatting port for persisted agent messages. Implemented
+// by the HTTP/WS adapter: it formats presentation DTOs and returns the WS
+// payloads; the service is responsible for delivering them (locally or via the
+// cross-instance relay).
 type ReplyPusher interface {
-	PushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage)
-	PushEvent(humanID uint64, payload map[string]interface{})
+	FormatAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) ([]map[string]interface{}, error)
 }
 
 func (s *AgentService) gatewayReady() bool {

--- a/internal/service/agent/agent_orchestrate.go
+++ b/internal/service/agent/agent_orchestrate.go
@@ -27,6 +27,7 @@ func (s *AgentService) RunReply(humanID uint64, conv *dm.DmConversation, userTex
 	// Any new generation supersedes an in-flight/paused one: cancel it and
 	// drop its state so its deltas are discarded and any paused-completed
 	// reply waiting to be persisted is abandoned.
+	s.publishControl(context.Background(), humanID, map[string]interface{}{"type": "supersede", "from": s.InstanceID})
 	s.supersedeGeneration(humanID)
 	// Register the generation synchronously so a WS agent_cancel arriving
 	// right after the send can never miss the in-flight generation.
@@ -36,6 +37,7 @@ func (s *AgentService) RunReply(humanID uint64, conv *dm.DmConversation, userTex
 		cancel()
 		return
 	}
+	s.snapshotRunning(humanID, genID, conv.ID)
 	runMu := s.runLock(humanID)
 	go func() {
 		defer cancel()
@@ -96,6 +98,22 @@ func (s *AgentService) ResumeReply(uid uint64, convID uint64) {
 	if s == nil || uid == 0 {
 		return
 	}
+	// If the generation is owned by another replica, forward the control
+	// command; the owner applies the exact same resume logic locally.
+	if snap := s.readSnapshot(uid); snap != nil && snap.Owner != "" && snap.Owner != s.InstanceID {
+		s.publishControl(context.Background(), uid, map[string]interface{}{
+			"type": "resume", "conv_id": convID, "from": s.InstanceID,
+		})
+		return
+	}
+	s.resumeReplyLocal(uid, convID)
+}
+
+// resumeReplyLocal is the single-instance resume implementation (owner path).
+func (s *AgentService) resumeReplyLocal(uid uint64, convID uint64) {
+	if s == nil || uid == 0 {
+		return
+	}
 	s.resumeGeneration(uid)
 	// Fast path: the generation is still running, so continue only needs to
 	// un-pause and flush the buffered deltas.
@@ -131,6 +149,38 @@ func (s *AgentService) ResumeReply(uid uint64, convID uint64) {
 	}
 	s.pushContinueMode(uid, "reprompt")
 	s.continueReply(uid, convID, draft)
+}
+
+// handleControl applies a cross-instance control command. Only the replica
+// that owns the user's running generation acts; everyone else ignores it.
+func (s *AgentService) handleControl(uid uint64, ctrl map[string]interface{}) {
+	if s == nil || uid == 0 {
+		return
+	}
+	// Ignore controls this instance published itself: the initiating path
+	// already applied them locally (e.g. RunReply superseded before starting
+	// the new generation; applying the echoed supersede would cancel it).
+	if from, _ := ctrl["from"].(string); from != "" && from == s.InstanceID {
+		return
+	}
+	switch ctrl["type"] {
+	case "pause":
+		if s.hasRunningGeneration(uid) {
+			s.pauseGeneration(uid)
+		}
+	case "resume":
+		snap := s.readSnapshot(uid)
+		if snap == nil || snap.Owner != s.InstanceID {
+			return
+		}
+		convID := uint64(0)
+		if v, ok := ctrl["conv_id"].(float64); ok {
+			convID = uint64(v)
+		}
+		s.resumeReplyLocal(uid, convID)
+	case "supersede":
+		s.supersedeGeneration(uid)
+	}
 }
 
 // RegenerateReply re-runs the assistant reply for the last user message in the
@@ -169,6 +219,7 @@ func (s *AgentService) RegenerateReply(uid uint64, convID uint64) {
 		return
 	}
 	// Regenerate supersedes any in-flight generation (RunReply re-checks).
+	s.publishControl(context.Background(), uid, map[string]interface{}{"type": "supersede", "from": s.InstanceID})
 	s.supersedeGeneration(uid)
 	s.RunReply(uid, conv, lastUser)
 }
@@ -196,9 +247,7 @@ func (s *AgentService) regenerateWelcome(uid uint64, conv *dm.DmConversation, cu
 		}
 		return
 	}
-	if s.Pusher != nil {
-		s.Pusher.PushAgentMessage(context.Background(), uid, conv, msg)
-	}
+	s.pushAgentMessage(context.Background(), uid, conv, msg)
 }
 
 // pickDifferentWelcome picks a random pool entry different from current,
@@ -244,6 +293,7 @@ func (s *AgentService) continueReply(uid uint64, convID uint64, partial string) 
 	if s == nil || s.Dm == nil || convID == 0 || strings.TrimSpace(partial) == "" {
 		return
 	}
+	s.publishControl(context.Background(), uid, map[string]interface{}{"type": "supersede", "from": s.InstanceID})
 	s.supersedeGeneration(uid)
 	ctx, cancel := context.WithCancel(context.Background())
 	genID := s.beginGeneration(uid, cancel)
@@ -251,6 +301,7 @@ func (s *AgentService) continueReply(uid uint64, convID uint64, partial string) 
 		cancel()
 		return
 	}
+	s.snapshotRunning(uid, genID, convID)
 	runMu := s.runLock(uid)
 	go func() {
 		defer cancel()
@@ -280,9 +331,7 @@ func (s *AgentService) continueReply(uid uint64, convID uint64, partial string) 
 			}
 			return
 		}
-		if s.Pusher != nil {
-			s.Pusher.PushAgentMessage(ctx, uid, conv, msg)
-		}
+		s.pushAgentMessage(ctx, uid, conv, msg)
 		go s.attachSuggestions(uid, msg.ID, full)
 	}()
 }
@@ -357,7 +406,7 @@ func (s *AgentService) continueFromDraft(ctx context.Context, conv *dm.DmConvers
 // streamTail paces the stitched continuation out as deltas so the fallback
 // still has a typewriter feel; the client never sees the unstitched seam.
 func (s *AgentService) streamTail(humanID uint64, genID uint64, tail string) {
-	if s.ChatHub == nil || tail == "" {
+	if (s.ChatHub == nil && s.Relay == nil) || tail == "" {
 		return
 	}
 	runes := []rune(tail)
@@ -392,10 +441,26 @@ func (s *AgentService) persistAndPushReply(humanID uint64, conv *dm.DmConversati
 		}
 		return nil
 	}
-	if s.Pusher != nil {
-		s.Pusher.PushAgentMessage(ctx, humanID, conv, msg)
-	}
+	s.pushAgentMessage(ctx, humanID, conv, msg)
 	return msg
+}
+
+// pushAgentMessage formats a persisted agent message through the Pusher
+// adapter and delivers every returned payload (locally or cross-instance).
+func (s *AgentService) pushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) {
+	if s == nil || s.Pusher == nil || humanID == 0 || conv == nil || msg == nil {
+		return
+	}
+	payloads, err := s.Pusher.FormatAgentMessage(ctx, humanID, conv, msg)
+	if err != nil {
+		if s.Log != nil {
+			s.Log.Error("agent format message", zap.Error(err))
+		}
+		return
+	}
+	for _, payload := range payloads {
+		s.publishEvent(ctx, humanID, payload)
+	}
 }
 
 // attachSuggestions generates follow-up chips after the reply is already
@@ -416,13 +481,11 @@ func (s *AgentService) attachSuggestions(humanID uint64, messageID uint64, reply
 		}
 		return
 	}
-	if s.Pusher != nil {
-		s.Pusher.PushEvent(humanID, map[string]interface{}{
-			"type":        "agent_suggestions",
-			"message_id":  messageID,
-			"suggestions": sugg,
-		})
-	}
+	s.publishEvent(ctx, humanID, map[string]interface{}{
+		"type":        "agent_suggestions",
+		"message_id":  messageID,
+		"suggestions": sugg,
+	})
 }
 
 // pushFallback persists and pushes an assistant fallback message.
@@ -434,18 +497,16 @@ func (s *AgentService) pushFallback(ctx context.Context, humanID uint64, conv *d
 		}
 		return
 	}
-	if s.Pusher != nil {
-		s.Pusher.PushAgentMessage(ctx, humanID, conv, msg)
-	}
+	s.pushAgentMessage(ctx, humanID, conv, msg)
 }
 
 // pushContinueMode tells the frontend whether a continue is a seamless buffer
 // replay or a re-prompt fallback.
 func (s *AgentService) pushContinueMode(uid uint64, mode string) {
-	if s == nil || s.Pusher == nil || uid == 0 {
+	if s == nil || uid == 0 {
 		return
 	}
-	s.Pusher.PushEvent(uid, map[string]interface{}{
+	s.publishEvent(context.Background(), uid, map[string]interface{}{
 		"type": "agent_continue_mode",
 		"mode": mode,
 	})

--- a/internal/service/agent/agent_orchestrate_test.go
+++ b/internal/service/agent/agent_orchestrate_test.go
@@ -24,16 +24,11 @@ type recordingPusher struct {
 	events   []map[string]interface{}
 }
 
-func (p *recordingPusher) PushAgentMessage(_ context.Context, _ uint64, _ *dm.DmConversation, msg *dm.DmMessage) {
+func (p *recordingPusher) FormatAgentMessage(_ context.Context, _ uint64, _ *dm.DmConversation, msg *dm.DmMessage) ([]map[string]interface{}, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.messages = append(p.messages, msg)
-}
-
-func (p *recordingPusher) PushEvent(_ uint64, payload map[string]interface{}) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.events = append(p.events, payload)
+	return []map[string]interface{}{{"type": "dm_message", "message": map[string]interface{}{"id": msg.ID}}}, nil
 }
 
 func (p *recordingPusher) messageCount() int {
@@ -83,6 +78,11 @@ func newOrchestrateService(t *testing.T) (*AgentService, *gorm.DB, *recordingPus
 		},
 		Dm:     dmSvc,
 		Pusher: pusher,
+	}
+	s.EventHook = func(_ uint64, payload map[string]interface{}) {
+		pusher.mu.Lock()
+		pusher.events = append(pusher.events, payload)
+		pusher.mu.Unlock()
 	}
 	return s, db, pusher
 }

--- a/internal/service/agent/agent_relay.go
+++ b/internal/service/agent/agent_relay.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+
+	"cakecake/internal/data"
+	"cakecake/internal/ws"
+)
+
+// AgentRelay is the cross-instance transport for agent WebSocket events and
+// generation control commands:
+//
+//   - events (agent_delta, tool frames, suggestions, dm_message, ...) are
+//     published to ChannelAgentEvent and every replica fans them out to its
+//     local ChatHub for the target user;
+//   - control commands (pause / resume / supersede) are published to
+//     ChannelAgentControl and only the replica that owns the user's running
+//     generation applies them (see AgentService.handleControl).
+//
+// With no relay wired (unit tests / single-process fallback) the service
+// pushes events straight to its local ChatHub.
+type AgentRelay struct {
+	Rdb *redis.Client
+	Hub *ws.ChatHub
+	Log *zap.Logger
+	Svc *AgentService
+}
+
+// NewAgentRelay wires Redis to the in-process ChatHub and the owning
+// AgentService (used for control dispatch).
+func NewAgentRelay(rdb *redis.Client, hub *ws.ChatHub, log *zap.Logger, svc *AgentService) *AgentRelay {
+	if log == nil {
+		log = zap.NewNop()
+	}
+	return &AgentRelay{Rdb: rdb, Hub: hub, Log: log, Svc: svc}
+}
+
+type agentEnvelope struct {
+	UID     uint64          `json:"uid"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// PublishEvent publishes one per-user agent event to Redis.
+func (r *AgentRelay) PublishEvent(ctx context.Context, uid uint64, payload interface{}) error {
+	if r == nil || r.Rdb == nil || uid == 0 {
+		return nil
+	}
+	return r.publish(ctx, data.ChannelAgentEvent, uid, payload)
+}
+
+// PublishControl publishes one cross-instance control command to Redis.
+func (r *AgentRelay) PublishControl(ctx context.Context, uid uint64, payload interface{}) error {
+	if r == nil || r.Rdb == nil || uid == 0 {
+		return nil
+	}
+	return r.publish(ctx, data.ChannelAgentControl, uid, payload)
+}
+
+func (r *AgentRelay) publish(ctx context.Context, channel string, uid uint64, payload interface{}) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	env := agentEnvelope{UID: uid, Payload: body}
+	b, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+	return r.Rdb.Publish(ctx, channel, b).Err()
+}
+
+// RunSubscriber blocks until ctx is cancelled; it must run in a goroutine per
+// process. Events are fanned out to the local ChatHub, control commands are
+// dispatched to the owning AgentService.
+func (r *AgentRelay) RunSubscriber(ctx context.Context) {
+	if r == nil || r.Rdb == nil {
+		return
+	}
+	sub := r.Rdb.Subscribe(ctx, data.ChannelAgentEvent, data.ChannelAgentControl)
+	defer func() { _ = sub.Close() }()
+
+	ch := sub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			if msg == nil || msg.Payload == "" {
+				continue
+			}
+			var env agentEnvelope
+			if err := json.Unmarshal([]byte(msg.Payload), &env); err != nil {
+				r.Log.Warn("agent relay: skip bad envelope", zap.Error(err))
+				continue
+			}
+			if env.UID == 0 || len(env.Payload) == 0 {
+				continue
+			}
+			switch msg.Channel {
+			case data.ChannelAgentEvent:
+				if r.Hub != nil {
+					r.Hub.PushRaw(env.UID, env.Payload)
+				}
+			case data.ChannelAgentControl:
+				var ctrl map[string]interface{}
+				if err := json.Unmarshal(env.Payload, &ctrl); err != nil {
+					r.Log.Warn("agent relay: skip bad control", zap.Error(err))
+					continue
+				}
+				if r.Svc != nil {
+					r.Svc.handleControl(env.UID, ctrl)
+				}
+			}
+		}
+	}
+}

--- a/internal/service/agent/agent_relay_test.go
+++ b/internal/service/agent/agent_relay_test.go
@@ -1,0 +1,111 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"cakecake/internal/service/servicetest"
+	"cakecake/internal/ws"
+)
+
+func startRelay(t *testing.T, svc *AgentService, hub *ws.ChatHub) {
+	t.Helper()
+	relay := NewAgentRelay(svc.Redis, hub, zap.NewNop(), svc)
+	svc.Relay = relay
+	ctx, cancel := context.WithCancel(context.Background())
+	go relay.RunSubscriber(ctx)
+	t.Cleanup(cancel)
+}
+
+func TestAgentSnapshot_LifecycleAndGuards(t *testing.T) {
+	_, rdb := servicetest.NewRedis(t)
+	s := &AgentService{Redis: rdb, InstanceID: "inst-1"}
+
+	s.snapshotRunning(7, 1, 42)
+	snap := s.readSnapshot(7)
+	require.NotNil(t, snap)
+	require.Equal(t, "inst-1", snap.Owner)
+	require.True(t, snap.Running)
+	require.Equal(t, uint64(42), snap.ConvID)
+
+	// A stale generation id must not clear the newer snapshot.
+	s.clearSnapshot(7, 2)
+	require.NotNil(t, s.readSnapshot(7))
+	s.clearSnapshot(7, 1)
+	require.Nil(t, s.readSnapshot(7))
+
+	s.snapshotRunning(7, 3, 42)
+	s.snapshotPending(7, 3, 42, &GenerateReplyResult{Content: "待落库"})
+	snap = s.readSnapshot(7)
+	require.NotNil(t, snap)
+	require.False(t, snap.Running)
+	require.NotNil(t, snap.Pending)
+	require.Equal(t, "待落库", snap.Pending.Content)
+}
+
+func TestHandleControl_IgnoresSelfPublishedSupersede(t *testing.T) {
+	_, rdb := servicetest.NewRedis(t)
+	svcA := &AgentService{Redis: rdb, InstanceID: "inst-a", Log: zap.NewNop()}
+	genID := svcA.beginGeneration(7, nil)
+	svcA.snapshotRunning(7, genID, 1)
+
+	// A supersede this instance published itself (echoed by the relay) must
+	// not cancel its own fresh generation.
+	svcA.handleControl(7, map[string]interface{}{"type": "supersede", "from": "inst-a"})
+	require.True(t, svcA.hasRunningGeneration(7))
+
+	// A supersede from another replica does cancel it.
+	svcA.handleControl(7, map[string]interface{}{"type": "supersede", "from": "inst-b"})
+	require.False(t, svcA.hasRunningGeneration(7))
+}
+
+// TestMultiInstance_PauseResumeAndEventFanout is the core multi-replica
+// evidence: instance A owns the generation, instance B holds the user's WS and
+// issues pause/resume; Redis Pub/Sub routes the controls to A and fans events
+// out to B's ChatHub.
+func TestMultiInstance_PauseResumeAndEventFanout(t *testing.T) {
+	_, rdb := servicetest.NewRedis(t)
+	const uid = uint64(77)
+	const convID = uint64(42)
+
+	// Instance A: generation owner (no local WS needed).
+	svcA := &AgentService{Redis: rdb, InstanceID: "inst-a", Log: zap.NewNop()}
+	startRelay(t, svcA, nil)
+
+	// Instance B: the replica holding the user's WebSocket connection.
+	hubB, connB := newStateTestHub(t, uid)
+	svcB := &AgentService{Redis: rdb, InstanceID: "inst-b", ChatHub: hubB, Log: zap.NewNop()}
+	startRelay(t, svcB, hubB)
+	time.Sleep(100 * time.Millisecond) // let both subscribers land
+
+	genID := svcA.beginGeneration(uid, nil)
+	require.NotZero(t, genID)
+	svcA.snapshotRunning(uid, genID, convID)
+
+	// A delta produced on A must reach B's local hub.
+	svcA.deltaSender(uid, genID)("你好")
+	d, ok := readDelta(t, connB)
+	require.True(t, ok)
+	require.Equal(t, "你好", d)
+
+	// Pause issued on B must reach A (the owner).
+	svcB.PauseGeneration(uid)
+	require.Eventually(t, func() bool { return svcA.isGenerationPaused(uid) }, 3*time.Second, 10*time.Millisecond)
+
+	// Deltas produced while paused are buffered on A.
+	svcA.deltaSender(uid, genID)("世界")
+
+	// Resume issued on B must reach A, flush the buffer, and fan it to B.
+	svcB.ResumeReply(uid, convID)
+	require.Eventually(t, func() bool { return !svcA.isGenerationPaused(uid) }, 3*time.Second, 10*time.Millisecond)
+	replayed, ok := readDelta(t, connB)
+	require.True(t, ok)
+	require.Equal(t, "世界", replayed)
+
+	svcA.endGeneration(uid, genID)
+	require.Nil(t, svcA.readSnapshot(uid))
+}

--- a/internal/service/agent/agent_snapshot.go
+++ b/internal/service/agent/agent_snapshot.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"cakecake/internal/data"
+)
+
+const agentSnapshotTTL = 24 * time.Hour
+
+// genSnapshot is the cross-instance view of a user's generation: enough for a
+// remote replica to route pause/resume/supersede to the owner, and to recover
+// a paused-completed reply when the owner is gone.
+type genSnapshot struct {
+	Owner    string       `json:"owner"`
+	GenID    uint64       `json:"gen_id"`
+	Running  bool         `json:"running"`
+	Paused   bool         `json:"paused"`
+	PauseSeq uint64       `json:"pause_seq"`
+	Dropped  bool         `json:"dropped"`
+	ConvID   uint64       `json:"conv_id"`
+	Pending  *pendingSnap `json:"pending,omitempty"`
+}
+
+// pendingSnap is the serialized paused-completed reply.
+type pendingSnap struct {
+	ConvID         uint64 `json:"conv_id"`
+	Content        string `json:"content"`
+	ToolActivities string `json:"tool_activities,omitempty"`
+	ToolResultData string `json:"tool_result_data,omitempty"`
+	Suggestions    string `json:"suggestions,omitempty"`
+}
+
+func (s *AgentService) writeSnapshot(uid uint64, snap *genSnapshot) {
+	if s == nil || s.Redis == nil || uid == 0 || snap == nil {
+		return
+	}
+	b, err := json.Marshal(snap)
+	if err != nil {
+		return
+	}
+	_ = s.Redis.Set(context.Background(), data.AgentGenSnapshotKey(uid), b, agentSnapshotTTL).Err()
+}
+
+func (s *AgentService) readSnapshot(uid uint64) *genSnapshot {
+	if s == nil || s.Redis == nil || uid == 0 {
+		return nil
+	}
+	raw, err := s.Redis.Get(context.Background(), data.AgentGenSnapshotKey(uid)).Bytes()
+	if err != nil {
+		return nil
+	}
+	var snap genSnapshot
+	if json.Unmarshal(raw, &snap) != nil {
+		return nil
+	}
+	return &snap
+}
+
+// clearSnapshot removes the snapshot only when it still belongs to genID (a
+// finished generation can never clear a newer generation's snapshot).
+func (s *AgentService) clearSnapshot(uid uint64, genID uint64) {
+	if s == nil || s.Redis == nil || uid == 0 || genID == 0 {
+		return
+	}
+	snap := s.readSnapshot(uid)
+	if snap == nil || snap.GenID != genID {
+		return
+	}
+	_ = s.Redis.Del(context.Background(), data.AgentGenSnapshotKey(uid)).Err()
+}
+
+// updateSnapshotPaused mirrors a local pause/resume change into the snapshot
+// (guarded by generation id).
+func (s *AgentService) updateSnapshotPaused(uid uint64, genID uint64, paused bool, pauseSeq uint64) {
+	if s == nil || s.Redis == nil || uid == 0 || genID == 0 {
+		return
+	}
+	snap := s.readSnapshot(uid)
+	if snap == nil || snap.GenID != genID {
+		return
+	}
+	snap.Paused = paused
+	snap.PauseSeq = pauseSeq
+	s.writeSnapshot(uid, snap)
+}
+
+// snapshotRunning marks the snapshot as a running generation owned by this
+// instance (called right after beginGeneration on the owner).
+func (s *AgentService) snapshotRunning(uid uint64, genID uint64, convID uint64) {
+	if s == nil || s.Redis == nil || uid == 0 || genID == 0 {
+		return
+	}
+	s.writeSnapshot(uid, &genSnapshot{
+		Owner:   s.InstanceID,
+		GenID:   genID,
+		Running: true,
+		ConvID:  convID,
+	})
+}
+
+// snapshotPending marks the snapshot as finished-while-paused with the reply
+// serialized, so a remote replica can recover it.
+func (s *AgentService) snapshotPending(uid uint64, genID uint64, convID uint64, result *GenerateReplyResult) {
+	if s == nil || s.Redis == nil || uid == 0 || genID == 0 || result == nil {
+		return
+	}
+	snap := s.readSnapshot(uid)
+	if snap == nil || snap.GenID != genID {
+		return
+	}
+	snap.Running = false
+	snap.Paused = true
+	snap.Pending = &pendingSnap{
+		ConvID:         convID,
+		Content:        result.Content,
+		ToolActivities: string(result.ToolActivities),
+		ToolResultData: string(result.ToolResultData),
+	}
+	if len(result.Suggestions) > 0 {
+		if b, err := json.Marshal(result.Suggestions); err == nil {
+			snap.Pending.Suggestions = string(b)
+		}
+	}
+	s.writeSnapshot(uid, snap)
+}

--- a/internal/service/agent/agent_state.go
+++ b/internal/service/agent/agent_state.go
@@ -65,8 +65,8 @@ func (s *AgentService) deltaSender(humanID uint64, genID uint64) func(string) {
 			}
 			st.mu.Unlock()
 		}
-		if s.ChatHub != nil {
-			s.ChatHub.PushJSON(humanID, map[string]interface{}{
+		if s.ChatHub != nil || s.Relay != nil {
+			s.publishEvent(context.Background(), humanID, map[string]interface{}{
 				"type": "agent_delta",
 				"body": map[string]interface{}{
 					"content": delta,
@@ -74,6 +74,34 @@ func (s *AgentService) deltaSender(humanID uint64, genID uint64) func(string) {
 			})
 		}
 	}
+}
+
+// publishEvent delivers an agent event to the user's WebSocket connection.
+// With a relay wired it is published to Redis and every replica fans it out to
+// its local ChatHub; without one it is pushed directly (single-process mode).
+func (s *AgentService) publishEvent(ctx context.Context, uid uint64, payload interface{}) {
+	if s == nil || uid == 0 {
+		return
+	}
+	if s.Relay != nil {
+		_ = s.Relay.PublishEvent(ctx, uid, payload)
+	} else if s.ChatHub != nil {
+		s.ChatHub.PushJSON(uid, payload)
+	}
+	if s.EventHook != nil {
+		if m, ok := payload.(map[string]interface{}); ok {
+			s.EventHook(uid, m)
+		}
+	}
+}
+
+// publishControl routes a cross-instance generation control command to the
+// owner (no-op without a relay).
+func (s *AgentService) publishControl(ctx context.Context, uid uint64, payload interface{}) {
+	if s == nil || uid == 0 || s.Relay == nil {
+		return
+	}
+	_ = s.Relay.PublishControl(ctx, uid, payload)
 }
 
 // draftText returns the full text streamed so far for the user's generation.
@@ -156,6 +184,7 @@ func (s *AgentService) endGeneration(uid uint64, genID uint64) {
 	}
 	delete(s.genStates, uid)
 	s.genMu.Unlock()
+	s.clearSnapshot(uid, genID)
 	s.saveDraft(uid, st)
 	if cancel := st.finish(); cancel != nil {
 		cancel()
@@ -241,6 +270,7 @@ func (s *AgentService) supersedeGeneration(uid uint64) {
 	st.pending = nil
 	st.draft = nil
 	st.buffer = nil
+	genID := st.genID
 	if st.cond != nil {
 		st.cond.Broadcast()
 	}
@@ -251,6 +281,7 @@ func (s *AgentService) supersedeGeneration(uid uint64) {
 	if cancel != nil {
 		cancel()
 	}
+	s.clearSnapshot(uid, genID)
 }
 
 // dropCurrentGeneration marks the user's current generation as dropped (its
@@ -310,9 +341,11 @@ func (s *AgentService) storePendingReply(uid uint64, genID uint64, conv *dm.DmCo
 	st.mu.Lock()
 	st.pending = &pendingAgentReply{conv: conv, result: result}
 	st.running = false
+	curGenID := st.genID
 	cancel := st.cancel
 	st.cancel = nil
 	st.mu.Unlock()
+	s.snapshotPending(uid, curGenID, conv.ID, result)
 	if cancel != nil {
 		cancel()
 	}
@@ -342,9 +375,23 @@ func (s *AgentService) takePendingReply(uid uint64) (*dm.DmConversation, *Genera
 	return p.conv, p.result, genID, true
 }
 
-// PauseGeneration stops pushing streamed deltas; they are buffered so a later
-// resumeGeneration can flush them verbatim (byte-level continuation).
+// PauseGeneration pauses the user's generation. A generation owned locally is
+// paused in place; when it runs on another replica, the control command is
+// routed to the owner via Redis.
 func (s *AgentService) PauseGeneration(uid uint64) {
+	if s == nil || uid == 0 {
+		return
+	}
+	if s.hasRunningGeneration(uid) {
+		s.pauseGeneration(uid)
+		return
+	}
+	s.publishControl(context.Background(), uid, map[string]interface{}{"type": "pause", "from": s.InstanceID})
+}
+
+// pauseGeneration stops pushing streamed deltas; they are buffered so a later
+// resumeGeneration can flush them verbatim (byte-level continuation).
+func (s *AgentService) pauseGeneration(uid uint64) {
 	if uid == 0 {
 		return
 	}
@@ -361,7 +408,10 @@ func (s *AgentService) PauseGeneration(uid uint64) {
 	st.mu.Lock()
 	st.paused = true
 	st.pauseSeq++
+	genID := st.genID
+	pauseSeq := st.pauseSeq
 	st.mu.Unlock()
+	s.updateSnapshotPaused(uid, genID, true, pauseSeq)
 }
 
 // resumeGeneration un-pauses and flushes the buffered deltas in order.
@@ -369,7 +419,7 @@ func (s *AgentService) resumeGeneration(uid uint64) {
 	if uid == 0 {
 		return
 	}
-	if s.ChatHub == nil {
+	if s.ChatHub == nil && s.Relay == nil {
 		return
 	}
 	for {
@@ -421,7 +471,7 @@ func (s *AgentService) resumeGeneration(uid uint64) {
 				return
 			}
 			st.mu.Unlock()
-			s.ChatHub.PushJSON(uid, map[string]interface{}{
+			s.publishEvent(context.Background(), uid, map[string]interface{}{
 				"type": "agent_delta",
 				"body": map[string]interface{}{"content": d},
 			})
@@ -457,6 +507,7 @@ func (s *AgentService) resumeGeneration(uid uint64) {
 		}
 		st.paused = false
 		st.mu.Unlock()
+		s.updateSnapshotPaused(uid, st.genID, false, seq)
 		return
 	}
 }


### PR DESCRIPTION
## Summary

Production hardening of the AI assistant chat chain (streaming / pause / continue / regenerate / follow-up suggestions / tool result cards), plus groundwork for horizontal scaling.

## What changed

- **Single source of truth for generation state**: the whole state machine (genID, pause buffer, pending replies) lives in `AgentService`; the HTTP/WS handler only forwards triggers, using the `DmReader` / `ReplyPusher` ports.
- **No-partial continue protocol**: the draft stays server-side; `agent_continue` no longer carries client text; `agent_continue_mode {buffer|reprompt}` tells the frontend which path is running.
- **Model-declared result cards**: the model ends its reply with a machine-only `【展示】tool#ID` line; the backend persists exactly those cards and strips the marker. Title matching is only a fallback, with per-sentence dismissal and cross-call dedupe.
- **Reliable regenerate**: picks the newest user message (previously the oldest), and regenerates the welcome message when no user turn exists; 120s frontend safety net.
- **Frontend**: true Vue 3 reactive composable (`useAgentStreaming`), pure `buildVersionGroups`, extracted presentational components; fixed layout regression and scroll-to-question behavior.
- **Multi-instance state externalization**: Redis Pub/Sub event/control channels (`minibili:agent:event` / `minibili:agent:control`) plus a per-user generation snapshot (`mb:agent:gen:{uid}`, owner/genID-guarded, TTL 24h). Events fan out to the replica holding the user's WebSocket; pause/continue/supersede route to the generation owner; hot-path buffering stays in the owner's memory.

## Verification

- Full Go integration suite passes (`go test -tags=integration ./...`), backend coverage ~72%.
- `go vet` clean; frontend `npm run build` passes.
- Real-browser + real-model end-to-end: send → stop → continue (no partial) → regenerate, welcome regenerate, and result-card counts all verified.
- Two-instance integration test (miniredis Pub/Sub): events fan out across replicas; pause/resume route to the owner.

## Notes for deployment

- Requires Redis (already used by the app); every replica must run the relay subscriber (wired in `cmd/cakecake/main.go`).
- The running backend must be rebuilt from this branch — the current production binary predates these changes.
- If the owner replica dies mid-pause, the paused-completed reply can be recovered from the snapshot's `pending` field; buffered replay falls back to a re-prompt.