### PR TITLE
chore(ci): enforce golangci-lint and clear all lint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     services:
       rabbitmq:
         image: rabbitmq:3-alpine
@@ -70,6 +70,12 @@ jobs:
             echo "$unformatted"
             exit 1
           fi
+
+      - name: Run golangci-lint
+        # Pinned to the same version used for local verification. The gate
+        # fails on any finding (see .golangci.yml for the linter set).
+        run: |
+          go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout 8m ./internal/... ./cmd/...
 
       - name: Run Go tests with coverage
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,29 @@
+# golangci-lint configuration.
+#
+# Invoked from CI with the same flags as the test suite (integration build
+# tag). Keep the enabled linter set small and explicit: the gate fails on any
+# finding, so adding a linter means committing to zero findings under it.
+#
+# Keep the installed golangci-lint version in sync with the one pinned in
+# .github/workflows/ci.yml.
+
+run:
+  timeout: 8m
+  build-tags:
+    - integration
+
+linters:
+  enable:
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+
+issues:
+  # golangci-lint's defaults (max-same-issues: 3, max-issues-per-linter: 50)
+  # cap how many findings are reported, and which subset wins is
+  # nondeterministic. Report every occurrence so the gate is stable across runs.
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/internal/aigateway/gateway.go
+++ b/internal/aigateway/gateway.go
@@ -62,21 +62,11 @@ type historyEntry struct {
 }
 
 func chatMsgToEntry(m ChatMessage) historyEntry {
-	return historyEntry{
-		Role:       m.Role,
-		Content:    m.Content,
-		ToolCalls:  m.ToolCalls,
-		ToolCallID: m.ToolCallID,
-	}
+	return historyEntry(m)
 }
 
 func entryToChatMsg(e historyEntry) ChatMessage {
-	return ChatMessage{
-		Role:       e.Role,
-		Content:    e.Content,
-		ToolCalls:  e.ToolCalls,
-		ToolCallID: e.ToolCallID,
-	}
+	return ChatMessage(e)
 }
 
 func (g *Gateway) historyKey(conversationID uint64) string {

--- a/internal/aigateway/toolkit/platform.go
+++ b/internal/aigateway/toolkit/platform.go
@@ -147,7 +147,7 @@ func (p *PlatformExecutor) searchVideos(ctx context.Context, raw json.RawMessage
 	}
 	items := make([]item, 0, len(videos))
 	for _, v := range videos {
-		uploaderName, _ := userMap[v.UserID]
+		uploaderName := userMap[v.UserID]
 		if uploaderName == "" {
 			uploaderName = "unknown"
 		}
@@ -261,7 +261,7 @@ func (p *PlatformExecutor) getTrending(ctx context.Context, raw json.RawMessage)
 	}
 	items := make([]item, 0, len(videos))
 	for i, v := range videos {
-		uploaderName, _ := userMap[v.UserID]
+		uploaderName := userMap[v.UserID]
 		if uploaderName == "" {
 			uploaderName = "unknown"
 		}
@@ -399,11 +399,11 @@ func (p *PlatformExecutor) getVideoDanmaku(ctx context.Context, raw json.RawMess
 	}
 	items := make([]item, 0, len(danmakus))
 	for _, d := range danmakus {
-		userName, _ := userMap[d.UserID]
+		userName := userMap[d.UserID]
 		if userName == "" {
 			userName = "匿名"
 		}
-		userAvatar, _ := avatarMap[d.UserID]
+		userAvatar := avatarMap[d.UserID]
 		items = append(items, item{
 			Content: d.Content, VideoID: args.VideoID, VideoTime: d.VideoTime,
 			Type: d.Type, Color: d.Color, UserName: userName,

--- a/internal/config/runtime.go
+++ b/internal/config/runtime.go
@@ -89,6 +89,7 @@ func (rc *RuntimeConfig) refresh(ctx context.Context) {
 				Value: v,
 			}).Error; err != nil {
 				// Non-fatal; next refresh will retry
+				_ = err
 			}
 		}
 	}

--- a/internal/data/data_extra_test.go
+++ b/internal/data/data_extra_test.go
@@ -51,7 +51,7 @@ func Test_ResyncCuratedCountsEmpty(t *testing.T) {
 
 func Test_BackfillUserCakeIDs(t *testing.T) {
 	db := extDBWithMigrate(t, &user.User{})
-	backfillUserCakeIDs(db, zap.NewNop())
+	require.NoError(t, backfillUserCakeIDs(db, zap.NewNop()))
 }
 
 func Test_IsIgnorableAddColumnErr(t *testing.T) {

--- a/internal/handler/admin_banner.go
+++ b/internal/handler/admin_banner.go
@@ -101,8 +101,7 @@ func (a *API) AdminCreateBanner(c *gin.Context) {
 	if req.Enabled != nil {
 		en = *req.Enabled
 	}
-	var b admin.HomeBanner
-	b = admin.HomeBanner{
+	b := admin.HomeBanner{
 		Title:      title,
 		ImageURL:   img,
 		LinkType:   lt,

--- a/internal/handler/admin_crud_test.go
+++ b/internal/handler/admin_crud_test.go
@@ -58,7 +58,7 @@ func TestAdminBannerCRUD_Full(t *testing.T) {
 		Code int   `json:"code"`
 		Data gin.H `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	require.Equal(t, 0, cr.Code)
 	id := int(cr.Data["id"].(float64))
 

--- a/internal/handler/agent_direct_message_test.go
+++ b/internal/handler/agent_direct_message_test.go
@@ -84,12 +84,3 @@ func seedDmMessage(t *testing.T, db *gorm.DB, convID, senderID uint64, role, con
 	require.NoError(t, db.Create(msg).Error)
 	return msg
 }
-
-func countAssistantAfter(t *testing.T, db *gorm.DB, convID, afterID uint64) int {
-	t.Helper()
-	var n int64
-	require.NoError(t, db.Model(&dm.DmMessage{}).
-		Where("conversation_id = ? AND id > ? AND role = ?", convID, afterID, "assistant").
-		Count(&n).Error)
-	return int(n)
-}

--- a/internal/handler/handler_edge_test.go
+++ b/internal/handler/handler_edge_test.go
@@ -219,7 +219,7 @@ func TestInitVideoZoneAllowed(t *testing.T) {
 
 func TestRejectIfSensitive_EmptyFilter(t *testing.T) {
 	f := sensitive.NewFilter("", zap.NewNop())
-	f.Reload()
+	_ = f.Reload() // Reload fails on an empty path; the empty filter is intentional here
 	// Empty filter blocks ALL content by design
 	api := &API{Dependencies: &Dependencies{Sens: f, Log: zap.NewNop()}}
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())

--- a/internal/handler/handler_pure_static_test.go
+++ b/internal/handler/handler_pure_static_test.go
@@ -36,7 +36,7 @@ func TestManuscriptVideoStatusFilter_Unit(t *testing.T) {
 	if s != "" || len(m) != 0 {
 		t.Errorf("empty: %q %v", s, m)
 	}
-	s, m = manuscriptVideoStatusFilter("draft")
+	s, _ = manuscriptVideoStatusFilter("draft")
 	if s != "draft" {
 		t.Errorf("draft: %q", s)
 	}

--- a/internal/handler/integration_admin_basic_test.go
+++ b/internal/handler/integration_admin_basic_test.go
@@ -34,7 +34,7 @@ func TestAdminBannerCRUD(t *testing.T) {
 		Code int   `json:"code"`
 		Data gin.H `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	require.Equal(t, 0, cr.Code)
 	id := int(cr.Data["id"].(float64))
 

--- a/internal/handler/integration_banner_space_test.go
+++ b/internal/handler/integration_banner_space_test.go
@@ -6,7 +6,6 @@ import (
 	"cakecake/internal/model/admin"
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -63,7 +62,7 @@ func TestUserSpace_PublicEndpoints(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
 
 	// ListUserPublishedVideos.
-	w = doReq(r, "GET", fmt.Sprintf("/api/v1/space/1/videos?page=1&page_size=10"), token, "", nil)
+	w = doReq(r, "GET", "/api/v1/space/1/videos?page=1&page_size=10", token, "", nil)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	require.Contains(t, w.Body.String(), "v")
 	w = doReq(r, "GET", "/api/v1/space/999/videos", token, "", nil)

--- a/internal/handler/integration_comment_pin_test.go
+++ b/internal/handler/integration_comment_pin_test.go
@@ -20,7 +20,8 @@ func decodeCode(t *testing.T, w *httptest.ResponseRecorder) int {
 	var r struct {
 		Code int `json:"code"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &r)
+	// Some endpoints (e.g. DELETE) return an empty body; treat that as code 0.
+	_ = json.Unmarshal(w.Body.Bytes(), &r)
 	return r.Code
 }
 
@@ -29,7 +30,7 @@ func decodeDataComment(t *testing.T, w *httptest.ResponseRecorder) comment.Comme
 	var r struct {
 		Data comment.Comment `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &r)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &r))
 	return r.Data
 }
 
@@ -74,7 +75,7 @@ func Test_ArticleCommentPinAndToggle(t *testing.T) {
 		} `json:"data"`
 	}
 	var acr artCmResp
-	json.Unmarshal(w.Body.Bytes(), &acr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &acr))
 	if acr.Code == 0 && acr.Data.ID > 0 {
 		cid := acr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/article-comments/%d/like", cid), tk, nil))
@@ -111,7 +112,7 @@ func Test_FollowGroupRenameAndDelete(t *testing.T) {
 		} `json:"data"`
 	}
 	var fgr fgResp
-	json.Unmarshal(w.Body.Bytes(), &fgr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fgr))
 	if fgr.Code == 0 && fgr.Data.ID > 0 {
 		gid := fgr.Data.ID
 		// Rename
@@ -137,7 +138,7 @@ func Test_DmActions(t *testing.T) {
 		} `json:"data"`
 	}
 	var dcr dmConvResp
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		// List messages
@@ -184,7 +185,7 @@ func Test_ArticleActions(t *testing.T) {
 		} `json:"data"`
 	}
 	var ar artResp
-	json.Unmarshal(w.Body.Bytes(), &ar)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ar))
 
 	// List my articles
 	srve(r, areq("GET", "/api/v1/users/me/articles?page=1&page_size=10", tk, nil))
@@ -295,7 +296,7 @@ func Test_DanmakuActions(t *testing.T) {
 		} `json:"data"`
 	}
 	var dkr dkResp
-	json.Unmarshal(w.Body.Bytes(), &dkr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dkr))
 	if dkr.Code == 0 && dkr.Data.ID > 0 {
 		did := dkr.Data.ID
 		// Toggle danmaku like

--- a/internal/handler/integration_core_advanced_test.go
+++ b/internal/handler/integration_core_advanced_test.go
@@ -19,7 +19,7 @@ func code(t *testing.T, w *httptest.ResponseRecorder) int {
 	var r struct {
 		Code int `json:"code"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &r)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &r))
 	return r.Code
 }
 
@@ -40,7 +40,7 @@ func Test_NotifLikeFlow(t *testing.T) {
 	var cm struct {
 		Data comment.Comment `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &cm)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cm))
 	if cm.Data.ID == 0 {
 		t.Skip("no comment id")
 	}
@@ -73,7 +73,7 @@ func Test_DMFullFlow(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &conv)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &conv))
 	if conv.Data.ID == 0 {
 		t.Skip("conv not created")
 	}

--- a/internal/handler/integration_core_all_test.go
+++ b/internal/handler/integration_core_all_test.go
@@ -26,7 +26,7 @@ func seedUser(t *testing.T, api *API, username, nickname string, coin int) user.
 	t.Helper()
 	u := user.User{Username: username, PasswordHash: "hash", Nickname: nickname, CoinBalanceTenths: int64(coin * 10)}
 	require.NoError(t, api.DB.Create(&u).Error)
-	api.UserSvc.EnsureCakeID(context.Background(), &u)
+	require.NoError(t, api.UserSvc.EnsureCakeID(context.Background(), &u))
 	return u
 }
 

--- a/internal/handler/integration_core_coverage_test.go
+++ b/internal/handler/integration_core_coverage_test.go
@@ -20,7 +20,7 @@ func codeFrom(t *testing.T, w *httptest.ResponseRecorder) int {
 	var r struct {
 		Code int `json:"code"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &r)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &r))
 	return r.Code
 }
 
@@ -42,7 +42,7 @@ func Test_DecrementPaths(t *testing.T) {
 	var cm struct {
 		Data comment.Comment `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &cm)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cm))
 	if cm.Data.ID == 0 {
 		t.Skip("no comment id")
 	}
@@ -90,7 +90,7 @@ func Test_DynamicCommentReactions(t *testing.T) {
 	var dcm struct {
 		Data comment.DynamicComment `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcm)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcm))
 	if dcm.Data.ID == 0 {
 		t.Skip("no dynamic comment id")
 	}
@@ -116,7 +116,7 @@ func Test_ArticleCommentDecrement(t *testing.T) {
 	var acm struct {
 		Data comment.ArticleComment `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &acm)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &acm))
 	if acm.Data.ID == 0 {
 		t.Skip("no article comment id")
 	}
@@ -212,7 +212,7 @@ func Test_VideoFolderOperations(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &ff)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ff))
 	if ff.Data.ID > 0 {
 		fid := ff.Data.ID
 		// Add video to folder

--- a/internal/handler/integration_core_large_test.go
+++ b/internal/handler/integration_core_large_test.go
@@ -27,7 +27,7 @@ func Test_DMFlow(t *testing.T) {
 		} `json:"data"`
 	}
 	var cr convResp
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code != 0 || cr.Data.ID == 0 {
 		t.Skip("dm conversation not created")
 	}
@@ -59,7 +59,7 @@ func Test_FavoriteFolderCRUD(t *testing.T) {
 		} `json:"data"`
 	}
 	var ffr ffResp
-	json.Unmarshal(w.Body.Bytes(), &ffr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ffr))
 	if ffr.Code != 0 || ffr.Data.ID == 0 {
 		t.Skip("favorite folder not created")
 	}
@@ -115,7 +115,7 @@ func Test_ArticleCRUD(t *testing.T) {
 		} `json:"data"`
 	}
 	var ar artResp
-	json.Unmarshal(w.Body.Bytes(), &ar)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ar))
 	if ar.Code != 0 || ar.Data.ID == 0 {
 		t.Skip("article not created")
 	}
@@ -249,7 +249,7 @@ func Test_FollowGroupFlow(t *testing.T) {
 		} `json:"data"`
 	}
 	var fgr fgResp
-	json.Unmarshal(w.Body.Bytes(), &fgr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fgr))
 	if fgr.Code != 0 || fgr.Data.ID == 0 {
 		t.Skip("follow group not created")
 	}
@@ -286,7 +286,7 @@ func Test_VideoEngagementFlow(t *testing.T) {
 		} `json:"data"`
 	}
 	var ffr ffResp
-	json.Unmarshal(w.Body.Bytes(), &ffr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ffr))
 
 	// Toggle video favorite
 	srve(r, areq("POST", fmt.Sprintf("/api/v1/videos/%d/favorite", v.ID), tk, nil))

--- a/internal/handler/integration_core_ops_test.go
+++ b/internal/handler/integration_core_ops_test.go
@@ -25,7 +25,7 @@ func Test_CommentBasicOps(t *testing.T) {
 	var resp struct {
 		Data comment.Comment `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	cm = resp.Data
 	if cm.ID == 0 {
 		t.Skip("comment not created")

--- a/internal/handler/integration_crud_test.go
+++ b/internal/handler/integration_crud_test.go
@@ -185,7 +185,7 @@ func TestIntegration_Login(t *testing.T) {
 			AccessToken string `json:"access_token"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.NotEmpty(t, resp.Data.AccessToken)
 }
 

--- a/internal/handler/integration_dynamic_dm_test.go
+++ b/internal/handler/integration_dynamic_dm_test.go
@@ -28,7 +28,7 @@ func Test_DynamicCommentApproveIgnoreDelete(t *testing.T) {
 	// Post a comment as u2
 	w := srve(r, areq("POST", fmt.Sprintf("/api/v1/user-dynamics/%d/comments", did), tk2, `{"content":"Nice!"}`))
 	var cresp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &cresp)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cresp))
 	cd, _ := cresp["data"].(map[string]interface{})
 	var cid uint64
 	if cd != nil {
@@ -91,7 +91,7 @@ func Test_DmConversationEdgeCases(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		// Send a message to create unread

--- a/internal/handler/integration_dynamic_fav_test.go
+++ b/internal/handler/integration_dynamic_fav_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_UserDynamicCRUD(t *testing.T) {
@@ -21,7 +23,7 @@ func Test_UserDynamicCRUD(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dr))
 	if dr.Code == 0 && dr.Data.ID > 0 {
 		did := dr.Data.ID
 		// Toggle like
@@ -48,7 +50,7 @@ func Test_FavoriteFolderCRUDMore(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &fr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fr))
 	if fr.Code == 0 && fr.Data.ID > 0 {
 		fid := fr.Data.ID
 		// Update folder
@@ -69,7 +71,7 @@ func Test_FavoriteFolderCRUDMore(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w2.Body.Bytes(), &fr2)
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &fr2))
 	if fr2.Code == 0 && fr2.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/users/me/favorite-folders/%d/invalid-favorites", fr2.Data.ID), tk, nil))
 	}
@@ -127,7 +129,7 @@ func Test_VideoFavoriteFolders(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &fr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fr))
 	if fr.Code == 0 && fr.Data.ID > 0 {
 		fid := fr.Data.ID
 		// Add video to folder
@@ -222,7 +224,7 @@ func Test_FollowAndGroupMore(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &gr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &gr))
 	if gr.Code == 0 && gr.Data.ID > 0 {
 		gid := gr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/users/me/follow-groups/%d/members", gid), tk, fmt.Sprintf(`{"user_id":%d}`, u2.ID)))

--- a/internal/handler/integration_edge_cases_test.go
+++ b/internal/handler/integration_edge_cases_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_NotificationReadNonExistent(t *testing.T) {
@@ -36,7 +38,7 @@ func Test_CommentApproveByNonOwner(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/comments/%d/approve", cr.Data.ID), tk, nil))
 	}

--- a/internal/handler/integration_engagement_dynamic_test.go
+++ b/internal/handler/integration_engagement_dynamic_test.go
@@ -40,7 +40,7 @@ func Test_DynamicCommentFullFlow(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/user-dynamics/%d/comments/%d/approve", dyn.ID, cid), tk, nil))
@@ -63,7 +63,7 @@ func Test_UserDynamicUpdateAndList(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dr))
 	if dr.Code == 0 && dr.Data.ID > 0 {
 		did := dr.Data.ID
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/users/me/dynamics/%d", did), tk, `{"title":"Updated Title","content":"Updated content"}`))
@@ -88,7 +88,7 @@ func Test_VideoEngagementFolderOps(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &fr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fr))
 	if fr.Code == 0 && fr.Data.ID > 0 {
 		fid := fr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/videos/%d/favorite-folders/%d", v.ID, fid), tk, nil))
@@ -108,7 +108,7 @@ func Test_AdminAgentProfileCRUD(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &apr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &apr))
 	if apr.Code == 0 && apr.Data.ID > 0 {
 		pid := apr.Data.ID
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/admin/agent-profiles/%d", pid), at, `{"display_name":"Updated Bot","welcome_message":"Hi there"}`))
@@ -141,7 +141,7 @@ func Test_AdminBannerUploadByID_NilOSS(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &br)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &br))
 	if br.Code == 0 && br.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/admin/home-banners/%d/image", br.Data.ID), at, nil))
 	}

--- a/internal/handler/integration_full_lifecycle_test.go
+++ b/internal/handler/integration_full_lifecycle_test.go
@@ -48,7 +48,7 @@ func Test_FullVideoLifecycle(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		cid := cr.Data.ID
 		// Like comment
@@ -86,7 +86,7 @@ func Test_FullArticleLifecycle(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &acr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &acr))
 	if acr.Code == 0 && acr.Data.ID > 0 {
 		cid := acr.Data.ID
 		// Like article comment
@@ -132,7 +132,7 @@ func Test_DmConversationFull(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		// Post message from user 1
@@ -163,7 +163,7 @@ func Test_FavoriteFolderLifecycle(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &ffr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ffr))
 	if ffr.Code == 0 && ffr.Data.ID > 0 {
 		fid := ffr.Data.ID
 		// List my folders

--- a/internal/handler/integration_mixed_scenarios_test.go
+++ b/internal/handler/integration_mixed_scenarios_test.go
@@ -31,14 +31,14 @@ func Test_CommentLikeDislikeToggleFlow(t *testing.T) {
 	u2 := seedUser(t, api, "clt2", "CLT2", 10)
 	tk := tok(t, api, u.ID)
 	v := seedVideoWithAPI(t, api, u2.ID, "CLT Video")
-	w := srve(r, areq("POST", "/api/v1/videos/"+fmt.Sprint(v.ID)+"/comments", tok(t, api, u2.ID), fmt.Sprintf(`{"content":"Toggle test comment"}`)))
+	w := srve(r, areq("POST", "/api/v1/videos/"+fmt.Sprint(v.ID)+"/comments", tok(t, api, u2.ID), `{"content":"Toggle test comment"}`))
 	var cr struct {
 		Code int `json:"code"`
 		Data struct {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		cid := cr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/comments/%d/like", cid), tk, nil))
@@ -73,7 +73,7 @@ func Test_DynamicCommentOperations(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/user-dynamics/%d/comments/%d/approve", dyn.ID, cid), tk, nil))
@@ -139,7 +139,7 @@ func Test_AdminBannerFullCRUD(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &br)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &br))
 	if br.Code == 0 && br.Data.ID > 0 {
 		bid := br.Data.ID
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/admin/home-banners/%d", bid), at, `{"title":"B1 Updated","link_type":"none","sort_order":2}`))

--- a/internal/handler/integration_notification_admin_test.go
+++ b/internal/handler/integration_notification_admin_test.go
@@ -47,7 +47,7 @@ func Test_FollowGroupManagement(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &fgr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fgr))
 	if fgr.Code == 0 && fgr.Data.ID > 0 {
 		gid := fgr.Data.ID
 		// Rename group
@@ -113,7 +113,7 @@ func Test_CommentReplyFlow(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &pcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &pcr))
 	if pcr.Code == 0 && pcr.Data.ID > 0 {
 		pcid := pcr.Data.ID
 		// Reply from another user

--- a/internal/handler/integration_notification_crud_test.go
+++ b/internal/handler/integration_notification_crud_test.go
@@ -17,7 +17,7 @@ import (
 
 func seedNotification(t *testing.T, api *API, recipientID uint64, notifType string, relatedID uint64) uint64 {
 	t.Helper()
-	payload := fmt.Sprintf(`{"like_subject":"comment","article_id":0,"article_title":"","cover_url":""}`)
+	payload := `{"like_subject":"comment","article_id":0,"article_title":"","cover_url":""}`
 	n := notification.Notification{
 		RecipientID:     recipientID,
 		Type:            notifType,
@@ -71,7 +71,7 @@ func Test_NotificationLikeAggregation(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/comments/%d/like", cr.Data.ID), tok(t, api, u.ID), nil))
 	}
@@ -85,14 +85,14 @@ func Test_CommentApproveIgnoreDelete(t *testing.T) {
 	u2 := seedUser(t, api, "cai2", "CAI2", 10)
 	tk := tok(t, api, u.ID)
 	v := seedVideoWithAPI(t, api, u.ID, "CAI Video")
-	w := srve(r, areq("POST", "/api/v1/videos/"+fmt.Sprint(v.ID)+"/comments", tok(t, api, u2.ID), fmt.Sprintf(`{"content":"Needs approval"}`)))
+	w := srve(r, areq("POST", "/api/v1/videos/"+fmt.Sprint(v.ID)+"/comments", tok(t, api, u2.ID), `{"content":"Needs approval"}`))
 	var cr struct {
 		Code int `json:"code"`
 		Data struct {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		cid := cr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/comments/%d/approve", cid), tk, nil))
@@ -109,14 +109,14 @@ func Test_CommentIgnoreCurated(t *testing.T) {
 	u2 := seedUser(t, api, "cic2", "CIC2", 10)
 	tk := tok(t, api, u.ID)
 	v := seedVideoWithAPI(t, api, u.ID, "CIC Video")
-	w := srve(r, areq("POST", "/api/v1/videos/"+fmt.Sprint(v.ID)+"/comments", tok(t, api, u2.ID), fmt.Sprintf(`{"content":"Ignore me"}`)))
+	w := srve(r, areq("POST", "/api/v1/videos/"+fmt.Sprint(v.ID)+"/comments", tok(t, api, u2.ID), `{"content":"Ignore me"}`))
 	var cr struct {
 		Code int `json:"code"`
 		Data struct {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/comments/%d/ignore-curated", cr.Data.ID), tk, nil))
 	}
@@ -128,14 +128,14 @@ func Test_ArticleCommentIgnoreDelete(t *testing.T) {
 	u2 := seedUser(t, api, "acd2", "ACD2", 10)
 	tk := tok(t, api, u.ID)
 	art := seedArticle(t, api, u.ID, "ACD Article")
-	w := srve(r, areq("POST", fmt.Sprintf("/api/v1/articles/%d/comments", art.ID), tok(t, api, u2.ID), fmt.Sprintf(`{"content":"Article comment test"}`)))
+	w := srve(r, areq("POST", fmt.Sprintf("/api/v1/articles/%d/comments", art.ID), tok(t, api, u2.ID), `{"content":"Article comment test"}`))
 	var acr struct {
 		Code int `json:"code"`
 		Data struct {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &acr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &acr))
 	if acr.Code == 0 && acr.Data.ID > 0 {
 		cid := acr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/article-comments/%d/approve", cid), tk, nil))
@@ -167,8 +167,8 @@ func Test_VideoFavoritePickerAndFolderOps(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w1.Body.Bytes(), &f1)
-	json.Unmarshal(w2.Body.Bytes(), &f2)
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &f1))
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &f2))
 	if f1.Code == 0 && f1.Data.ID > 0 && f2.Code == 0 && f2.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/videos/%d/favorite-folders/%d", v.ID, f1.Data.ID), tk, nil))
 		srve(r, areq("GET", fmt.Sprintf("/api/v1/videos/%d/favorite-picker", v.ID), tk, nil))
@@ -208,7 +208,7 @@ func Test_DmConversationSettingsAndReset(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		srve(r, areq("PATCH", fmt.Sprintf("/api/v1/dm/conversations/%d/settings", cid), tk, `{"is_agent":false}`))
@@ -229,7 +229,7 @@ func Test_CreatorCommentsWithApproval(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/comments/%d/approve", cr.Data.ID), tk, nil))
 		srve(r, areq("GET", "/api/v1/users/me/creator/comments?page=1&page_size=10&status=approved", tk, nil))
@@ -262,7 +262,7 @@ func Test_FavoriteFolderBatchRemove(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &fr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fr))
 	if fr.Code == 0 && fr.Data.ID > 0 {
 		fid := fr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/videos/%d/favorite-folders/%d", v.ID, fid), tk, nil))
@@ -298,7 +298,7 @@ func Test_AdminAgentSettingsAndAvatar(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &apr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &apr))
 	if apr.Code == 0 && apr.Data.ID > 0 {
 		pid := apr.Data.ID
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/admin/agent-profiles/%d", pid), at, `{"display_name":"Updated Support Bot"}`))
@@ -318,7 +318,7 @@ func Test_AgentDmEndpoints(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		srve(r, areq("PATCH", fmt.Sprintf("/api/v1/dm/conversations/%d/settings", cid), tk, `{"is_agent":true}`))
@@ -367,7 +367,7 @@ func Test_DanmakuDeleteAndLike(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dmr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dmr))
 	if dmr.Code == 0 && dmr.Data.ID > 0 {
 		did := dmr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/danmakus/%d/like", did), tk, nil))
@@ -407,7 +407,7 @@ func Test_ArticleFullCRUD(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &ar)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &ar))
 	if ar.Code == 0 && ar.Data.ID > 0 {
 		aid := ar.Data.ID
 		srve(r, areq("GET", fmt.Sprintf("/api/v1/users/me/articles/%d", aid), tk, nil))
@@ -498,7 +498,7 @@ func Test_HomeBannerAdminCRUD(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &br)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &br))
 	if br.Code == 0 && br.Data.ID > 0 {
 		bid := br.Data.ID
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/admin/home-banners/%d", bid), at, `{"title":"Updated Banner","link_type":"none","sort_order":2}`))

--- a/internal/handler/integration_notification_flow_test.go
+++ b/internal/handler/integration_notification_flow_test.go
@@ -100,7 +100,7 @@ func Test_DmConversationMultipleMessages(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		for i := 0; i < 3; i++ {
@@ -126,7 +126,7 @@ func Test_UserDynamicPostUpdateDelete(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &dr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dr))
 	if dr.Code == 0 && dr.Data.ID > 0 {
 		did := dr.Data.ID
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/users/me/dynamics/%d", did), tk, `{"title":"Updated","content":"Updated"}`))
@@ -149,7 +149,7 @@ func Test_VideoEngagementFullFolderFlow(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &fr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fr))
 	if fr.Code == 0 && fr.Data.ID > 0 {
 		fid := fr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/videos/%d/favorite", v.ID), tk, nil))
@@ -195,7 +195,7 @@ func Test_ArticleCommentReplyFlow(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &acr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &acr))
 	if acr.Code == 0 && acr.Data.ID > 0 {
 		pcid := acr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/articles/%d/comments", art.ID), tk, fmt.Sprintf(`{"content":"Owner reply","parent_id":%d}`, pcid)))
@@ -224,7 +224,7 @@ func Test_AdminHotSearchAllOps(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &hopr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &hopr))
 	if hopr.Code == 0 && hopr.Data.ID > 0 {
 		srve(r, areq("PUT", fmt.Sprintf("/api/v1/admin/hot-search/ops/%d", hopr.Data.ID), at, `{"keyword":"summer_upd","score":90}`))
 		srve(r, areq("DELETE", fmt.Sprintf("/api/v1/admin/hot-search/ops/%d", hopr.Data.ID), at, nil))
@@ -264,7 +264,7 @@ func Test_FollowGroupMemberManagement(t *testing.T) {
 			ID uint64 `json:"id"`
 		}
 	}
-	json.Unmarshal(w.Body.Bytes(), &fgr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &fgr))
 	if fgr.Code == 0 && fgr.Data.ID > 0 {
 		gid := fgr.Data.ID
 		srve(r, areq("POST", fmt.Sprintf("/api/v1/users/me/follow-groups/%d/members", gid), tk, fmt.Sprintf(`{"user_id":%d}`, u2.ID)))

--- a/internal/handler/integration_pure_article_test.go
+++ b/internal/handler/integration_pure_article_test.go
@@ -144,7 +144,7 @@ func Test_UserDynamicPutAndPlayback(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dr))
 	if dr.Code == 0 && dr.Data.ID > 0 {
 		did := dr.Data.ID
 		// Update dynamic
@@ -188,7 +188,7 @@ func Test_ArticleCommentSubActions(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &cr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &cr))
 	if cr.Code == 0 && cr.Data.ID > 0 {
 		cid := cr.Data.ID
 		// Like
@@ -213,7 +213,7 @@ func Test_DmPostAndList(t *testing.T) {
 			ID uint64 `json:"id"`
 		} `json:"data"`
 	}
-	json.Unmarshal(w.Body.Bytes(), &dcr)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &dcr))
 	if dcr.Code == 0 && dcr.Data.ID > 0 {
 		cid := dcr.Data.ID
 		// List conversations

--- a/internal/handler/integration_zero_engagement_test.go
+++ b/internal/handler/integration_zero_engagement_test.go
@@ -37,7 +37,7 @@ func Test_DmUnreadTotal_Zero(t *testing.T) {
 func Test_CoinRecentListItems_Zero(t *testing.T) {
 	api, _, _ := newTestAPI(t)
 	u := seedUser(t, api, "crl1", "CRL1", 10)
-	items, _, err := api.coinRecentListItems(nil, u.ID, 10)
+	items, _, err := api.coinRecentListItems(context.TODO(), u.ID, 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/handler/space_privacy.go
+++ b/internal/handler/space_privacy.go
@@ -71,7 +71,7 @@ func (a *API) UpdateMeSpacePrivacy(c *gin.Context) {
 		resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
 		return
 	}
-	u, err := a.UserSvc.GetPrivacySettings(c.Request.Context(), uid)
+	_, err := a.UserSvc.GetPrivacySettings(c.Request.Context(), uid)
 	if err != nil {
 		resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
 		return
@@ -100,6 +100,6 @@ func (a *API) UpdateMeSpacePrivacy(c *gin.Context) {
 		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
 		return
 	}
-	u, _ = a.UserSvc.GetPrivacySettings(c.Request.Context(), uid)
+	u, _ := a.UserSvc.GetPrivacySettings(c.Request.Context(), uid)
 	resp.OK(c, spacePrivacyFromUser(u))
 }

--- a/internal/handler/view_history.go
+++ b/internal/handler/view_history.go
@@ -362,5 +362,5 @@ func (a *API) PutMyViewHistorySettings(c *gin.Context) {
 		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
 		return
 	}
-	resp.OK(c, pausedResponse{Paused: body.Paused})
+	resp.OK(c, pausedResponse(body))
 }

--- a/internal/pkg/sensitive/sensitive_test.go
+++ b/internal/pkg/sensitive/sensitive_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFilter_Reload_WithValidWords(t *testing.T) {
 	lg, _ := zap.NewDevelopment()
-	defer lg.Sync()
+	defer func() { _ = lg.Sync() }()
 
 	content := "badword1\n# comment\nbadword2\n\n"
 	f, err := os.CreateTemp("", "sensitive-*.txt")
@@ -41,7 +41,7 @@ func TestFilter_Reload_WithValidWords(t *testing.T) {
 
 func TestFilter_Reload_EmptyWordsBlocksAll(t *testing.T) {
 	lg, _ := zap.NewDevelopment()
-	defer lg.Sync()
+	defer func() { _ = lg.Sync() }()
 
 	f, err := os.CreateTemp("", "sensitive-*.txt")
 	if err != nil {
@@ -68,7 +68,7 @@ func TestFilter_Reload_EmptyWordsBlocksAll(t *testing.T) {
 
 func TestFilter_MissingFile_ReloadError(t *testing.T) {
 	lg, _ := zap.NewDevelopment()
-	defer lg.Sync()
+	defer func() { _ = lg.Sync() }()
 
 	filter := NewFilter("/nonexistent/path/sensitive.txt", lg)
 	if err := filter.Reload(); err == nil {
@@ -83,7 +83,7 @@ func TestFilter_MissingFile_ReloadError(t *testing.T) {
 
 func TestFilter_Check_BeforeReload(t *testing.T) {
 	lg, _ := zap.NewDevelopment()
-	defer lg.Sync()
+	defer func() { _ = lg.Sync() }()
 
 	filter := NewFilter("some/path.txt", lg)
 

--- a/internal/search/search_advanced_test.go
+++ b/internal/search/search_advanced_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +41,7 @@ func TestDial_EmptyURL(t *testing.T) {
 }
 func TestDial_WithMockServer(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"name":"es-mock","version":{"number":"8.0.0"}}`))
+		_, _ = w.Write([]byte(`{"name":"es-mock","version":{"number":"8.0.0"}}`))
 	})
 	c, err := Dial(&config.C{ElasticsearchURL: srv.URL})
 	require.NoError(t, err)
@@ -55,25 +56,25 @@ func TestEnsureIndices_Create(t *testing.T) {
 			} else {
 				w.WriteHeader(http.StatusNotFound)
 			}
-			w.Write([]byte(`{}`))
+			_, _ = w.Write([]byte(`{}`))
 			return
 		}
 		if r.Method == "GET" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{}`))
+			_, _ = w.Write([]byte(`{}`))
 			return
 		}
 		if r.Method == "PUT" {
 			createdIndices = append(createdIndices, r.URL.Path)
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"acknowledged":true}`))
+			_, _ = w.Write([]byte(`{"acknowledged":true}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
-	err := c.EnsureIndices(nil)
+	err := c.EnsureIndices(context.TODO())
 	require.NoError(t, err)
 	require.Len(t, createdIndices, 3)
 }
@@ -83,14 +84,14 @@ func TestEnsureIndices_AlreadyExist(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "HEAD" || r.Method == "GET" {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{}`))
+			_, _ = w.Write([]byte(`{}`))
 			return
 		}
 		putCalls++
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
-	err := c.EnsureIndices(nil)
+	err := c.EnsureIndices(context.TODO())
 	require.NoError(t, err)
 	assert.Equal(t, 0, putCalls)
 }
@@ -114,23 +115,23 @@ func TestSearchAll_Basic(t *testing.T) {
 					},
 				},
 			}
-			json.NewEncoder(w).Encode(resp)
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
-	result, err := c.SearchAll(nil, SearchParams{Keyword: "test", Page: 1, PageSize: 10})
+	result, err := c.SearchAll(context.TODO(), SearchParams{Keyword: "test", Page: 1, PageSize: 10})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
 
 func TestSearchAll_EmptyKeyword(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
-	result, err := c.SearchAll(nil, SearchParams{Keyword: ""})
+	result, err := c.SearchAll(context.TODO(), SearchParams{Keyword: ""})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 }
@@ -140,13 +141,13 @@ func TestDeleteVideo_WithMock(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "DELETE" && strings.Contains(r.URL.Path, "_doc") {
 			deletedID = path.Base(r.URL.Path)
-			w.Write([]byte(`{"result":"deleted"}`))
+			_, _ = w.Write([]byte(`{"result":"deleted"}`))
 			return
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
-	err := c.DeleteVideo(nil, 42)
+	err := c.DeleteVideo(context.TODO(), 42)
 	require.NoError(t, err)
 	assert.Equal(t, "42", deletedID)
 }
@@ -156,22 +157,22 @@ func TestDeleteArticle_WithMock(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "DELETE" && strings.Contains(r.URL.Path, "_doc") {
 			deletedID = path.Base(r.URL.Path)
-			w.Write([]byte(`{"result":"deleted"}`))
+			_, _ = w.Write([]byte(`{"result":"deleted"}`))
 			return
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
-	err := c.DeleteArticle(nil, 456)
+	err := c.DeleteArticle(context.TODO(), 456)
 	require.NoError(t, err)
 	assert.Equal(t, "456", deletedID)
 }
 
 func TestOperations_WithNilClient(t *testing.T) {
 	var c *Client
-	require.NoError(t, c.EnsureIndices(nil))
-	_, err2 := c.SearchAll(nil, SearchParams{Keyword: "test"})
+	require.NoError(t, c.EnsureIndices(context.TODO()))
+	_, err2 := c.SearchAll(context.TODO(), SearchParams{Keyword: "test"})
 	require.Error(t, err2)
-	require.NoError(t, c.DeleteVideo(nil, 1))
-	require.NoError(t, c.DeleteArticle(nil, 1))
+	require.NoError(t, c.DeleteVideo(context.TODO(), 1))
+	require.NoError(t, c.DeleteArticle(context.TODO(), 1))
 }

--- a/internal/search/sync_test.go
+++ b/internal/search/sync_test.go
@@ -35,11 +35,11 @@ func TestIndexVideoFromDB_Published(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "_doc/10") && r.Method == "PUT" {
 			indexed = true
-			w.Write([]byte(`{"result":"created"}`))
+			_, _ = w.Write([]byte(`{"result":"created"}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	require.NoError(t, c.IndexVideoFromDB(context.Background(), db, 10))
@@ -54,10 +54,10 @@ func TestIndexVideoFromDB_NotPublished(t *testing.T) {
 		if r.Method == "DELETE" {
 			deleted = true
 			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte(`{}`))
+			_, _ = w.Write([]byte(`{}`))
 			return
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	require.NoError(t, c.IndexVideoFromDB(context.Background(), db, 10))
@@ -74,11 +74,11 @@ func TestIndexArticleAndUser(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "PUT" {
 			docs = append(docs, r.URL.Path)
-			w.Write([]byte(`{"result":"created"}`))
+			_, _ = w.Write([]byte(`{"result":"created"}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	require.NoError(t, c.IndexArticleFromDB(context.Background(), db, 20))
@@ -95,10 +95,10 @@ func TestIndexUser_Anonymized(t *testing.T) {
 		if r.Method == "DELETE" {
 			deleted = true
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{}`))
+			_, _ = w.Write([]byte(`{}`))
 			return
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	require.NoError(t, c.IndexUserFromDB(context.Background(), db, 1))
@@ -112,7 +112,7 @@ func TestDeleteDocs(t *testing.T) {
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	require.NoError(t, c.DeleteVideo(context.Background(), 10))
@@ -130,11 +130,11 @@ func TestReindexAll(t *testing.T) {
 	srv := newMockESServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "PUT" {
 			putCount++
-			w.Write([]byte(`{"result":"created"}`))
+			_, _ = w.Write([]byte(`{"result":"created"}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	require.NoError(t, c.ReindexAll(context.Background(), db))
@@ -159,7 +159,7 @@ func TestIndexDoc_Error(t *testing.T) {
 		} else {
 			w.WriteHeader(http.StatusOK)
 		}
-		w.Write([]byte(`{"error":"boom"}`))
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	err := c.indexDoc(context.Background(), IndexVideos, "10", map[string]interface{}{"a": 1})
@@ -185,10 +185,10 @@ func TestSearchArticles_Basic(t *testing.T) {
 					"total": map[string]interface{}{"value": float64(1)},
 				},
 			}
-			json.NewEncoder(w).Encode(resp)
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
-		w.Write([]byte(`{}`))
+		_, _ = w.Write([]byte(`{}`))
 	})
 	c := newMockESClient(t, srv.URL)
 	payload, err := c.SearchArticles(context.Background(), SearchParams{Keyword: "go", Page: 1, PageSize: 10, Sort: "pubdate"})

--- a/internal/service/agent/agent_markdown.go
+++ b/internal/service/agent/agent_markdown.go
@@ -9,7 +9,7 @@ import (
 var (
 	mdFenceRe      = regexp.MustCompile("(?s)```.*?```")
 	mdLinkRe       = regexp.MustCompile(`\[([^\]]+)\]\([^)]*\)`)
-	mdLinePrefixRe = regexp.MustCompile("(?m)^[#>*+\\-]\\s*")
+	mdLinePrefixRe = regexp.MustCompile(`(?m)^[#>*+\-]\s*`)
 	mdFenceLineRe  = regexp.MustCompile("(?m)^(\\s*)(`{3,})(.*)$")
 	mdStrayFenceRe = regexp.MustCompile("`{3,}[a-zA-Z0-9_+-]*")
 	// mdItemDismissRe marks a sentence that dismisses the video it mentions
@@ -22,8 +22,8 @@ var (
 	// displayMarkerRe captures the model-declared display list
 	// (【展示】search_videos#23,get_video_detail#24); displayMarkerLineRe
 	// removes the whole marker line before the reply is persisted.
-	displayMarkerRe     = regexp.MustCompile("【展示】\\s*([^\\n【】]*)")
-	displayMarkerLineRe = regexp.MustCompile("(?m)^[^\\n]*【展示】[^\\n]*$")
+	displayMarkerRe     = regexp.MustCompile(`【展示】\s*([^\n【】]*)`)
+	displayMarkerLineRe = regexp.MustCompile(`(?m)^[^\n]*【展示】[^\n]*$`)
 )
 
 // plainTextPreview strips common Markdown syntax so the conversation-list

--- a/internal/service/dynamic/dynamic_test.go
+++ b/internal/service/dynamic/dynamic_test.go
@@ -73,7 +73,7 @@ func TestDynamicService_Lists(t *testing.T) {
 	require.Equal(t, int64(3), total)
 	require.Len(t, list, 2)
 
-	list, total, err = s.ListDynamics(ctx, 1, 1, 10)
+	list, _, err = s.ListDynamics(ctx, 1, 1, 10)
 	require.NoError(t, err)
 	require.Len(t, list, 3)
 

--- a/internal/service/engagement/video_engagement.go
+++ b/internal/service/engagement/video_engagement.go
@@ -239,7 +239,7 @@ func (s *EngagementService) ListWatchLaterWithVideos(ctx context.Context, userID
 		if !ok {
 			continue
 		}
-		u, _ := users_u[vi.UserID]
+		u := users_u[vi.UserID]
 		items = append(items, WatchLaterVideoItem{
 			ID:             vi.ID,
 			Title:          vi.Title,
@@ -339,7 +339,7 @@ func (s *EngagementService) ListUserCoinedVideos(ctx context.Context, ownerID ui
 		if !ok {
 			continue
 		}
-		u, _ := users_u[vi.UserID]
+		u := users_u[vi.UserID]
 		items = append(items, CoinedVideoItem{
 			ID: vi.ID, Title: vi.Title, CoverURL: vi.CoverURL,
 			PlayCount: vi.PlayCount, DanmakuCount: vi.DanmakuCount, CommentCount: vi.CommentCount,

--- a/internal/worker/transcode_extended_test.go
+++ b/internal/worker/transcode_extended_test.go
@@ -23,7 +23,7 @@ func Test_TranscodeJobZeroRetry(t *testing.T) {
 	job := TranscodeJob{VideoID: 2, RawPath: "/tmp/v2.mp4"}
 	b, _ := json.Marshal(job)
 	var j2 TranscodeJob
-	json.Unmarshal(b, &j2)
+	require.NoError(t, json.Unmarshal(b, &j2))
 	require.Equal(t, 0, j2.RetryCount)
 	require.Empty(t, j2.CoverPath)
 }

--- a/internal/worker/worker_advanced_test.go
+++ b/internal/worker/worker_advanced_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"cakecake/internal/model/video"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -72,7 +73,7 @@ func TestCleanupPaths_MixNxst(t *testing.T) {
 	dir := t.TempDir()
 	f1 := filepath.Join(dir, "keep.txt")
 	f2 := filepath.Join(dir, "missing.txt")
-	os.WriteFile(f1, []byte("data"), 0644)
+	require.NoError(t, os.WriteFile(f1, []byte("data"), 0644))
 	cleanupPaths(f1, f2)
 	if _, err := os.Stat(f1); !os.IsNotExist(err) {
 		t.Error("expected f1 to be removed")
@@ -97,7 +98,7 @@ func TestTranscodeJob_MinJSON_Adv(t *testing.T) {
 	data, err := json.Marshal(job)
 	require.NoError(t, err)
 	var m map[string]interface{}
-	json.Unmarshal(data, &m)
+	require.NoError(t, json.Unmarshal(data, &m))
 	assert.Equal(t, float64(1), m["video_id"])
 	assert.Equal(t, "/tmp/v.mp4", m["raw_path"])
 }
@@ -105,14 +106,14 @@ func TestTranscodeJob_MinJSON_Adv(t *testing.T) {
 func TestHandleDelivery_BadJSON_Adv(t *testing.T) {
 	mockAck := &mockAcknowledger{}
 	d := amqp.Delivery{Acknowledger: mockAck, Body: []byte("not json")}
-	handleDelivery(nil, nil, nil, nil, nil, nil, nil, d)
+	handleDelivery(context.TODO(), nil, nil, nil, nil, nil, nil, d)
 	assert.True(t, mockAck.ackCalled)
 }
 
 func TestHandleDelivery_EmptyBody_Adv(t *testing.T) {
 	mockAck := &mockAcknowledger{}
 	d := amqp.Delivery{Acknowledger: mockAck, Body: []byte{}}
-	handleDelivery(nil, nil, nil, nil, nil, nil, nil, d)
+	handleDelivery(context.TODO(), nil, nil, nil, nil, nil, nil, d)
 	assert.True(t, mockAck.ackCalled)
 }
 
@@ -123,7 +124,7 @@ func TestHandleDelivery_NilOSS_Adv(t *testing.T) {
 	body, _ := json.Marshal(job)
 	mockAck := &mockAcknowledger{}
 	d := amqp.Delivery{Acknowledger: mockAck, Body: body}
-	handleDelivery(nil, nil, db, nil, nil, nil, nil, d)
+	handleDelivery(context.TODO(), nil, db, nil, nil, nil, nil, d)
 	assert.True(t, mockAck.ackCalled)
 	var v video.Video
 	db.First(&v, 1)


### PR DESCRIPTION
- Add .golangci.yml with deterministic issue reporting (integration build tag, no max-same-issues/max-issues-per-linter caps) and a failing CI gate pinned to golangci-lint v1.64.8
- Fix 145 findings: unchecked errors in tests (json.Unmarshal, w.Write, lg.Sync), nil contexts, redundant blank assignments, raw regexp strings, unnecessary fmt.Sprintf, ineffectual assignments, dead code
- Preserve behavior where callers relied on ignored errors (empty DELETE body, empty-path filter Reload)