### PR TITLE
style(handler): fix receiver naming and enforce exported comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,20 @@ jobs:
         run: |
           go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8 run --timeout 8m ./internal/... ./cmd/...
 
+      - name: Check exported comments
+        # golint is inactivated inside golangci-lint v1.64.8, so exported-comment
+        # strictness is enforced with the standalone golint binary, filtered to
+        # missing or misformatted exported comments only.
+        run: |
+          set -o pipefail
+          out=$(go run golang.org/x/lint/golint@v0.0.0-20241112194109-818c5a804067 ./internal/... ./cmd/... 2>&1)
+          issues=$(printf '%s\n' "$out" | grep -E 'should have comment or be unexported|comment on exported' || true)
+          if [ -n "$issues" ]; then
+            echo "Exported comments missing or misformatted:"
+            printf '%s\n' "$issues"
+            exit 1
+          fi
+
       - name: Run Go tests with coverage
         env:
           RABBITMQ_URL: amqp://guest:guest@localhost:5672/

--- a/internal/aigateway/gateway.go
+++ b/internal/aigateway/gateway.go
@@ -25,7 +25,7 @@ const defaultSystemPrompt = `你是 cakecake 站内 AI 助手。帮助用户了�
 
 const maxToolIterations = 5
 
-// Progress callbacks for front-end tool call display.
+// ToolCallStartCB is a progress callback for front-end tool call display.
 type ToolCallStartCB func(traceID, spanID, parentSpanID, toolName string, argsJSON json.RawMessage)
 
 // ToolCallEndCB is invoked when a tool call finishes.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,7 +247,6 @@ func Load() *C {
 	}
 }
 
-// OSSObjectURL builds the browser-accessible URL for an object key.
 // MarshalLogObject implements zapcore.ObjectMarshaler for safe zap.Any logging.
 func (c *C) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("app_env", c.AppEnv)

--- a/internal/handler/favorite_folder.go
+++ b/internal/handler/favorite_folder.go
@@ -539,6 +539,7 @@ func (a *API) validateFolderOwnedByUser(ctx context.Context, uid, folderID uint6
 	return err == nil && f.UserID == uid
 }
 
+// ClearInvalidFavoritesInFolder removes favorite references to deleted videos.
 // @Summary      Clear invalid favorites in folder
 // @Description  Remove references to deleted videos from a folder
 // @Tags         Favorites

--- a/internal/pkg/usercoin/usercoin.go
+++ b/internal/pkg/usercoin/usercoin.go
@@ -10,7 +10,7 @@ import (
 const (
 	// DefaultCoinTenths is the initial balance for new users (23.0 coins).
 	DefaultCoinTenths int64 = 230
-	// TenthsPerCoin: balance is stored in 0.1-coin units (10 tenths = 1 coin).
+	// TenthsPerCoin is the number of 0.1-coin units per coin (10).
 	TenthsPerCoin int64 = 10
 	// DailyLoginCoinTenths is the daily login grant (1 coin).
 	DailyLoginCoinTenths int64 = 10

--- a/internal/pkg/userlevel/userlevel.go
+++ b/internal/pkg/userlevel/userlevel.go
@@ -3,7 +3,8 @@ package userlevel
 // MaxLevel is the highest user level (Lv6).
 const MaxLevel = 6
 
-// Thresholds[i] is the minimum total experience required to reach level i+1.
+// Thresholds holds the minimum total experience required to reach each level.
+// Thresholds[i] is the minimum total experience for level i+1.
 // Lv1: 0, Lv2: 20, Lv3: 150, Lv4: 450, Lv5: 1080, Lv6: 2880.
 var Thresholds = []uint64{0, 20, 150, 450, 1080, 2880}
 

--- a/internal/service/agent/agent.go
+++ b/internal/service/agent/agent.go
@@ -22,7 +22,6 @@ import (
 	"cakecake/internal/ws"
 )
 
-// AgentService runs AI assistant replies for agent DM threads.
 // GenerateReplyResult holds the AI reply along with tool call metadata for persistence.
 type GenerateReplyResult struct {
 	Content        string          `json:"content"`
@@ -403,7 +402,6 @@ func (s *AgentService) agentSystemPrompt(profile *agent.AgentProfile) func() {
 	return func() { s.Gateway.SystemPrompt = prev }
 }
 
-// toolActivityCollector captures tool calls/results so they can be persisted.
 // ResetConversation clears an agent conversation and posts a fresh opening message.
 func (s *AgentService) ResetConversation(ctx context.Context, conv *dm.DmConversation, humanID uint64) (*dm.DmMessage, error) {
 	if s == nil || s.Store == nil || conv == nil || humanID == 0 {

--- a/internal/service/agent/agent_profiles.go
+++ b/internal/service/agent/agent_profiles.go
@@ -23,6 +23,7 @@ func (s *AgentService) NormalizeSlug(slug string) (string, error) {
 	return data.NormalizeAgentSlug(slug)
 }
 
+// ReloadProfiles reloads agent profiles (no-op; profiles are ensured lazily).
 func (s *AgentService) ReloadProfiles() {}
 
 // ListAgentProfiles returns all agent profiles.

--- a/internal/service/agent/agent_provider.go
+++ b/internal/service/agent/agent_provider.go
@@ -100,6 +100,7 @@ func (s *AgentStoreImpl) SetMessageFeedback(ctx context.Context, messageID uint6
 	}).Error
 }
 
+// ListAgentFeedbacks returns feedback rows ordered by newest first.
 func (s *AgentStoreImpl) ListAgentFeedbacks(ctx context.Context, limit int, offset int) ([]agent.AgentFeedback, error) {
 	if limit <= 0 || limit > 200 {
 		limit = 50
@@ -125,6 +126,7 @@ type AgentFeedbackRow struct {
 	MessageContent string `gorm:"column:message_content" json:"message_content"`
 }
 
+// ListAgentFeedbacksWithContent joins feedback rows with assistant message content.
 func (s *AgentStoreImpl) ListAgentFeedbacksWithContent(ctx context.Context, limit int, offset int) ([]AgentFeedbackRow, error) {
 	if limit <= 0 || limit > 200 {
 		limit = 50
@@ -147,28 +149,28 @@ func (s *AgentStoreImpl) ListAgentFeedbacksWithContent(ctx context.Context, limi
 }
 
 // EnsureAllAgentConversationsForUser ensures threads exist for each enabled profile.
-func (p *AgentStoreImpl) EnsureAllAgentConversationsForUser(humanID uint64) error {
-	return data.EnsureAllAgentConversationsForUser(p.db, humanID)
+func (s *AgentStoreImpl) EnsureAllAgentConversationsForUser(humanID uint64) error {
+	return data.EnsureAllAgentConversationsForUser(s.db, humanID)
 }
 
 // GetAgentProfileByBotUserID loads the profile for a bot user id.
-func (p *AgentStoreImpl) GetAgentProfileByBotUserID(botUserID uint64) (*agent.AgentProfile, error) {
-	return data.GetAgentProfileByBotUserID(p.db, botUserID)
+func (s *AgentStoreImpl) GetAgentProfileByBotUserID(botUserID uint64) (*agent.AgentProfile, error) {
+	return data.GetAgentProfileByBotUserID(s.db, botUserID)
 }
 
 // GetAgentProfile loads a profile by id.
-func (p *AgentStoreImpl) GetAgentProfile(id uint64) (*agent.AgentProfile, error) {
-	return data.GetAgentProfile(p.db, id)
+func (s *AgentStoreImpl) GetAgentProfile(id uint64) (*agent.AgentProfile, error) {
+	return data.GetAgentProfile(s.db, id)
 }
 
 // GetGlobalSystemPrompt returns the global agent system prompt.
-func (p *AgentStoreImpl) GetGlobalSystemPrompt() string {
-	return data.GetGlobalSystemPrompt(p.db)
+func (s *AgentStoreImpl) GetGlobalSystemPrompt() string {
+	return data.GetGlobalSystemPrompt(s.db)
 }
 
 // PostAssistantMessageTx persists an assistant message and updates conversation state atomically.
-func (p *AgentStoreImpl) PostAssistantMessageTx(msg *dm.DmMessage, conv *dm.DmConversation, humanID uint64, now time.Time, preview string) error {
-	return p.db.Transaction(func(tx *gorm.DB) error {
+func (s *AgentStoreImpl) PostAssistantMessageTx(msg *dm.DmMessage, conv *dm.DmConversation, humanID uint64, now time.Time, preview string) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(msg).Error; err != nil {
 			return err
 		}
@@ -188,8 +190,8 @@ func (p *AgentStoreImpl) PostAssistantMessageTx(msg *dm.DmMessage, conv *dm.DmCo
 }
 
 // ResetConversationTx clears conversation history, writes the opening message, and resets state atomically.
-func (p *AgentStoreImpl) ResetConversationTx(conv *dm.DmConversation, msg *dm.DmMessage, humanID uint64, now time.Time, preview string) error {
-	return p.db.Transaction(func(tx *gorm.DB) error {
+func (s *AgentStoreImpl) ResetConversationTx(conv *dm.DmConversation, msg *dm.DmMessage, humanID uint64, now time.Time, preview string) error {
+	return s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Where("conversation_id = ?", conv.ID).Delete(&dm.DmMessage{}).Error; err != nil {
 			return err
 		}
@@ -212,74 +214,74 @@ func (p *AgentStoreImpl) ResetConversationTx(conv *dm.DmConversation, msg *dm.Dm
 }
 
 // ReloadConversation refreshes a conversation row from the database.
-func (p *AgentStoreImpl) ReloadConversation(conv *dm.DmConversation) error {
-	return p.db.First(conv, conv.ID).Error
+func (s *AgentStoreImpl) ReloadConversation(conv *dm.DmConversation) error {
+	return s.db.First(conv, conv.ID).Error
 }
 
 // ListAgentProfiles lists all agent profiles.
-func (p *AgentStoreImpl) ListAgentProfiles(ctx context.Context) ([]agent.AgentProfile, error) {
+func (s *AgentStoreImpl) ListAgentProfiles(ctx context.Context) ([]agent.AgentProfile, error) {
 	var rows []agent.AgentProfile
-	if err := p.db.WithContext(ctx).Order("id ASC").Find(&rows).Error; err != nil {
+	if err := s.db.WithContext(ctx).Order("id ASC").Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
 // CreateAgentProfile inserts an agent profile.
-func (p *AgentStoreImpl) CreateAgentProfile(ctx context.Context, profile *agent.AgentProfile) error {
-	return p.db.WithContext(ctx).Create(profile).Error
+func (s *AgentStoreImpl) CreateAgentProfile(ctx context.Context, profile *agent.AgentProfile) error {
+	return s.db.WithContext(ctx).Create(profile).Error
 }
 
 // UpdateAgentProfile applies partial updates to an agent profile.
-func (p *AgentStoreImpl) UpdateAgentProfile(ctx context.Context, id uint64, updates map[string]interface{}) error {
-	return p.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("id = ?", id).Updates(updates).Error
+func (s *AgentStoreImpl) UpdateAgentProfile(ctx context.Context, id uint64, updates map[string]interface{}) error {
+	return s.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("id = ?", id).Updates(updates).Error
 }
 
 // DeleteAgentProfile removes an agent profile by id.
-func (p *AgentStoreImpl) DeleteAgentProfile(ctx context.Context, id uint64) error {
-	return p.db.WithContext(ctx).Delete(&agent.AgentProfile{}, id).Error
+func (s *AgentStoreImpl) DeleteAgentProfile(ctx context.Context, id uint64) error {
+	return s.db.WithContext(ctx).Delete(&agent.AgentProfile{}, id).Error
 }
 
 // CountActiveAgentProfiles counts enabled profiles.
-func (p *AgentStoreImpl) CountActiveAgentProfiles(ctx context.Context) (int64, error) {
+func (s *AgentStoreImpl) CountActiveAgentProfiles(ctx context.Context) (int64, error) {
 	var cnt int64
-	err := p.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("enabled = ?", true).Count(&cnt).Error
+	err := s.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("enabled = ?", true).Count(&cnt).Error
 	return cnt, err
 }
 
 // CheckAgentSlugExists reports whether a profile slug is taken.
-func (p *AgentStoreImpl) CheckAgentSlugExists(ctx context.Context, slug string) (bool, error) {
+func (s *AgentStoreImpl) CheckAgentSlugExists(ctx context.Context, slug string) (bool, error) {
 	var cnt int64
-	err := p.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("slug = ?", slug).Count(&cnt).Error
+	err := s.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("slug = ?", slug).Count(&cnt).Error
 	return cnt > 0, err
 }
 
 // UpdateAgentAvatar sets a profile's avatar URL.
-func (p *AgentStoreImpl) UpdateAgentAvatar(ctx context.Context, id uint64, avatarURL string) error {
-	return p.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("id = ?", id).Update("avatar_url", avatarURL).Error
+func (s *AgentStoreImpl) UpdateAgentAvatar(ctx context.Context, id uint64, avatarURL string) error {
+	return s.db.WithContext(ctx).Model(&agent.AgentProfile{}).Where("id = ?", id).Update("avatar_url", avatarURL).Error
 }
 
 // ProfileCount counts all agent profiles.
-func (p *AgentStoreImpl) ProfileCount(ctx context.Context) (int64, error) {
-	return data.ProfileCount(p.db)
+func (s *AgentStoreImpl) ProfileCount(ctx context.Context) (int64, error) {
+	return data.ProfileCount(s.db)
 }
 
 // CreateAgentBotUser creates the bot user backing a profile.
-func (p *AgentStoreImpl) CreateAgentBotUser(ctx context.Context, slug, displayName, sign, avatarURL string) (uint64, error) {
-	return data.CreateAgentBotUser(p.db, slug, displayName, sign, avatarURL)
+func (s *AgentStoreImpl) CreateAgentBotUser(ctx context.Context, slug, displayName, sign, avatarURL string) (uint64, error) {
+	return data.CreateAgentBotUser(s.db, slug, displayName, sign, avatarURL)
 }
 
 // RenameAgentProfileSlug renames a profile's slug.
-func (p *AgentStoreImpl) RenameAgentProfileSlug(ctx context.Context, profile *agent.AgentProfile, newSlug string) error {
-	return data.RenameAgentProfileSlug(p.db, profile, newSlug)
+func (s *AgentStoreImpl) RenameAgentProfileSlug(ctx context.Context, profile *agent.AgentProfile, newSlug string) error {
+	return data.RenameAgentProfileSlug(s.db, profile, newSlug)
 }
 
 // SyncAgentProfile mirrors profile display fields to the bot user row.
-func (p *AgentStoreImpl) SyncAgentProfile(ctx context.Context, profile *agent.AgentProfile) error {
-	return data.SyncAgentProfile(p.db, profile)
+func (s *AgentStoreImpl) SyncAgentProfile(ctx context.Context, profile *agent.AgentProfile) error {
+	return data.SyncAgentProfile(s.db, profile)
 }
 
 // EnsureAgentProfiles runs the startup migration that guarantees a default profile.
-func (p *AgentStoreImpl) EnsureAgentProfiles(cfg *config.C, log *zap.Logger) error {
-	return data.EnsureAgentProfiles(p.db, cfg, log)
+func (s *AgentStoreImpl) EnsureAgentProfiles(cfg *config.C, log *zap.Logger) error {
+	return data.EnsureAgentProfiles(s.db, cfg, log)
 }

--- a/internal/service/agent/agent_tools.go
+++ b/internal/service/agent/agent_tools.go
@@ -95,6 +95,7 @@ func (s *AgentService) clearToolCallbacks() {
 	}
 }
 
+// toolActivityCollector captures tool calls/results so they can be persisted.
 type toolActivityCollector struct {
 	mu      sync.Mutex
 	acts    []map[string]interface{}

--- a/internal/service/dynamic/dynamic.go
+++ b/internal/service/dynamic/dynamic.go
@@ -175,7 +175,7 @@ func (p *DynamicStoreImpl) ListUserDynamicsCursor(ctx context.Context, userID ui
 	return list, nil
 }
 
-// ListMyDynamicsAdvanced lists user dynamics with advanced filtering (title search, custom sort).
+// MyDynamicFilter filters dynamics by owner, title and sort key.
 type MyDynamicFilter struct {
 	UserID   uint64
 	TitleQ   string

--- a/internal/service/hotsearch/hot_search_service.go
+++ b/internal/service/hotsearch/hot_search_service.go
@@ -124,7 +124,6 @@ func (s *HotSearchService) QuickOpCreateOrUpdate(ctx context.Context, opType, ke
 	return &op, true, nil
 }
 
-// ReorderItems persists drag order and updates pin_rank for pin/manual ops.
 // ReorderItem represents one entry in a reorder request.
 type ReorderItem struct {
 	Keyword string

--- a/internal/service/hotsearch/search_hot.go
+++ b/internal/service/hotsearch/search_hot.go
@@ -19,7 +19,7 @@ const (
 	prefixHotSearchDed = "hotsearch:dedup:"
 	prefixHotSearchNew = "hotsearch:badge:new:"
 
-	// HotSearchDedupTTL: the same user/IP searching the same term within the window counts only once.
+	// HotSearchDedupTTL is the dedup window: the same user/IP searching the same term counts once.
 	HotSearchDedupTTL = 10 * time.Minute
 	hotSearchNewTTL   = 48 * time.Hour
 )

--- a/internal/service/search_contract.go
+++ b/internal/service/search_contract.go
@@ -6,14 +6,22 @@ import "cakecake/internal/search"
 // layer can depend on service (and later a gRPC contract) instead of the
 // search infrastructure package directly.
 type (
-	AllResult           = search.AllResult
+	// AllResult is the aggregate search result across all content types.
+	AllResult = search.AllResult
+	// SearchResultBuckets groups results by content type.
 	SearchResultBuckets = search.SearchResultBuckets
-	TopTlist            = search.TopTlist
-	VideoHit            = search.VideoHit
-	ArticleHit          = search.ArticleHit
-	UserHit             = search.UserHit
-	SearchParams        = search.SearchParams
-	VideoFilter         = search.VideoFilter
+	// TopTlist is a top-N result list for one content type.
+	TopTlist = search.TopTlist
+	// VideoHit is a single video search hit.
+	VideoHit = search.VideoHit
+	// ArticleHit is a single article search hit.
+	ArticleHit = search.ArticleHit
+	// UserHit is a single user search hit.
+	UserHit = search.UserHit
+	// SearchParams carries keyword, paging and filter options.
+	SearchParams = search.SearchParams
+	// VideoFilter carries video-specific filter options.
+	VideoFilter = search.VideoFilter
 )
 
 // ValidateKeyword wraps the shared keyword validation rule.

--- a/internal/service/video/video.go
+++ b/internal/service/video/video.go
@@ -184,7 +184,7 @@ func (s *VideoService) ListUserPublishedVideosCursor(ctx context.Context, uid ui
 	return s.videos.ListUserPublishedVideosCursor(ctx, uid, cursorID, limit)
 }
 
-// ListMyVideosAdvanced lists user videos with advanced filtering (title search, custom sort, multi-status).
+// MyVideoFilter filters the caller's videos by status.
 type MyVideoFilter struct {
 	UserID   uint64
 	Status   string   // single status


### PR DESCRIPTION
- Fix 19 inconsistent AgentStoreImpl receiver names (p -> s) in internal/service/agent/agent_provider.go
- Fix 22 exported-comment issues: 3 missing comments added, 19 comments rewritten to start with the exported identifier (incl. 8 search contract type aliases); removed misplaced duplicate doc comments
- Enforce exported comments in CI: pinned standalone golint filtered to missing/misformatted exported-comment messages fails the build (golangci-lint v1.64.8 inactivates golint; revive args are broken there)
- golint: 151 -> 110 findings; remaining are stutter/naming, intentionally left for the Kratos migration