### PR TITLE
refactor(service): add compile-time interface assertions for all prov…

### DIFF
--- a/internal/service/agent/agent_provider.go
+++ b/internal/service/agent/agent_provider.go
@@ -48,6 +48,8 @@ type AgentStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ AgentStore = (*AgentStoreImpl)(nil)
+
 // NewAgentStore creates a gorm-backed AgentStore implementation.
 func NewAgentStore(db *gorm.DB) *AgentStoreImpl {
 	return &AgentStoreImpl{db: db}

--- a/internal/service/article/article_provider.go
+++ b/internal/service/article/article_provider.go
@@ -49,6 +49,8 @@ type ArticleStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ ArticleStore = (*ArticleStoreImpl)(nil)
+
 // NewArticleStore creates a gorm-backed ArticleStore implementation.
 func NewArticleStore(db *gorm.DB) *ArticleStoreImpl {
 	return &ArticleStoreImpl{db: db}

--- a/internal/service/banner/banner.go
+++ b/internal/service/banner/banner.go
@@ -34,6 +34,8 @@ type BannerStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ BannerStore = (*BannerStoreImpl)(nil)
+
 // NewBannerStore creates a gorm-backed BannerStore implementation.
 func NewBannerStore(db *gorm.DB) *BannerStoreImpl {
 	return &BannerStoreImpl{db: db}

--- a/internal/service/comment/comment_provider.go
+++ b/internal/service/comment/comment_provider.go
@@ -73,6 +73,8 @@ type CommentProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ CommentProvider = (*CommentProviderImpl)(nil)
+
 // NewCommentProvider creates a gorm-backed CommentProvider implementation.
 func NewCommentProvider(db *gorm.DB) *CommentProviderImpl {
 	return &CommentProviderImpl{db: db}

--- a/internal/service/comment/creator_comment.go
+++ b/internal/service/comment/creator_comment.go
@@ -57,6 +57,8 @@ type CreatorCommentProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ CreatorCommentProvider = (*CreatorCommentProviderImpl)(nil)
+
 // NewCreatorCommentProvider creates a gorm-backed creator comment store.
 func NewCreatorCommentProvider(db *gorm.DB) *CreatorCommentProviderImpl {
 	return &CreatorCommentProviderImpl{db: db}

--- a/internal/service/dailyreward/daily_reward_service.go
+++ b/internal/service/dailyreward/daily_reward_service.go
@@ -30,6 +30,8 @@ type DailyRewardStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ DailyRewardStore = (*DailyRewardStoreImpl)(nil)
+
 // NewDailyRewardStore creates a gorm-backed daily-reward store.
 func NewDailyRewardStore(db *gorm.DB) *DailyRewardStoreImpl {
 	return &DailyRewardStoreImpl{db: db}

--- a/internal/service/danmaku/danmaku_provider.go
+++ b/internal/service/danmaku/danmaku_provider.go
@@ -31,6 +31,8 @@ type DanmakuStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ DanmakuStore = (*DanmakuStoreImpl)(nil)
+
 // NewDanmakuStore creates a gorm-backed DanmakuStore implementation.
 func NewDanmakuStore(db *gorm.DB) *DanmakuStoreImpl {
 	return &DanmakuStoreImpl{db: db}

--- a/internal/service/dm/dm.go
+++ b/internal/service/dm/dm.go
@@ -46,6 +46,8 @@ type DmStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ DmStore = (*DmStoreImpl)(nil)
+
 // NewDmStore creates a gorm-backed DmStore implementation.
 func NewDmStore(db *gorm.DB) *DmStoreImpl {
 	return &DmStoreImpl{db: db}

--- a/internal/service/dynamic/dynamic.go
+++ b/internal/service/dynamic/dynamic.go
@@ -44,6 +44,8 @@ type DynamicStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ DynamicStore = (*DynamicStoreImpl)(nil)
+
 // NewDynamicStore creates a gorm-backed DynamicStore implementation.
 func NewDynamicStore(db *gorm.DB) *DynamicStoreImpl {
 	return &DynamicStoreImpl{db: db}

--- a/internal/service/engagement/engagement_provider.go
+++ b/internal/service/engagement/engagement_provider.go
@@ -41,6 +41,8 @@ type EngagementStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ EngagementStore = (*EngagementStoreImpl)(nil)
+
 // NewEngagementStore creates a gorm-backed EngagementStore implementation.
 func NewEngagementStore(db *gorm.DB) *EngagementStoreImpl {
 	return &EngagementStoreImpl{db: db}

--- a/internal/service/favorite/favorite_provider.go
+++ b/internal/service/favorite/favorite_provider.go
@@ -52,6 +52,8 @@ type FavoriteStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ FavoriteStore = (*FavoriteStoreImpl)(nil)
+
 // NewFavoriteStore creates a gorm-backed FavoriteStore implementation.
 func NewFavoriteStore(db *gorm.DB) *FavoriteStoreImpl {
 	return &FavoriteStoreImpl{db: db}

--- a/internal/service/follow/follow.go
+++ b/internal/service/follow/follow.go
@@ -54,6 +54,8 @@ type FollowStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ FollowStore = (*FollowStoreImpl)(nil)
+
 // NewFollowStore creates a gorm-backed FollowStore implementation.
 func NewFollowStore(db *gorm.DB) *FollowStoreImpl {
 	return &FollowStoreImpl{db: db}

--- a/internal/service/hotsearch/hot_search_provider.go
+++ b/internal/service/hotsearch/hot_search_provider.go
@@ -40,6 +40,8 @@ type HotSearchProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ HotSearchProvider = (*HotSearchProviderImpl)(nil)
+
 // NewHotSearchProvider creates a gorm-backed HotSearchProvider implementation.
 func NewHotSearchProvider(db *gorm.DB) *HotSearchProviderImpl {
 	return &HotSearchProviderImpl{db: db}

--- a/internal/service/notification/notification_provider.go
+++ b/internal/service/notification/notification_provider.go
@@ -35,6 +35,8 @@ type NotificationStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ NotificationStore = (*NotificationStoreImpl)(nil)
+
 // NewNotificationStore creates a gorm-backed NotificationStore implementation.
 func NewNotificationStore(db *gorm.DB) *NotificationStoreImpl {
 	return &NotificationStoreImpl{db: db}

--- a/internal/service/playcount/playcount.go
+++ b/internal/service/playcount/playcount.go
@@ -27,6 +27,8 @@ type PlayCountStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ PlayCountStore = (*PlayCountStoreImpl)(nil)
+
 // NewPlayCountStore creates a gorm-backed play-count store.
 func NewPlayCountStore(db *gorm.DB) *PlayCountStoreImpl {
 	return &PlayCountStoreImpl{db: db}

--- a/internal/service/providers.go
+++ b/internal/service/providers.go
@@ -13,6 +13,8 @@ type ArticleProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ ArticleProvider = (*ArticleProviderImpl)(nil)
+
 // NewArticleProvider creates a gorm-backed ArticleProvider implementation.
 func NewArticleProvider(db *gorm.DB) *ArticleProviderImpl {
 	return &ArticleProviderImpl{db: db}
@@ -52,6 +54,8 @@ func (p *ArticleProviderImpl) IncrCommentCount(ctx context.Context, id uint64, d
 type DynamicProviderImpl struct {
 	db *gorm.DB
 }
+
+var _ DynamicProvider = (*DynamicProviderImpl)(nil)
 
 // NewDynamicProvider creates a gorm-backed DynamicProvider implementation.
 func NewDynamicProvider(db *gorm.DB) *DynamicProviderImpl {

--- a/internal/service/search/search_history.go
+++ b/internal/service/search/search_history.go
@@ -37,6 +37,8 @@ type SearchHistoryStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ SearchHistoryStore = (*SearchHistoryStoreImpl)(nil)
+
 // NewSearchHistoryStore creates a gorm-backed search-history store.
 func NewSearchHistoryStore(db *gorm.DB) *SearchHistoryStoreImpl {
 	return &SearchHistoryStoreImpl{db: db}

--- a/internal/service/search/search_service.go
+++ b/internal/service/search/search_service.go
@@ -39,6 +39,8 @@ type SearchStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ SearchStore = (*SearchStoreImpl)(nil)
+
 // NewSearchStore creates a gorm-backed SearchStore implementation.
 func NewSearchStore(db *gorm.DB) *SearchStoreImpl {
 	return &SearchStoreImpl{db: db}

--- a/internal/service/user/auth.go
+++ b/internal/service/user/auth.go
@@ -30,6 +30,8 @@ type AdminProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ AdminProvider = (*AdminProviderImpl)(nil)
+
 // NewAdminProvider creates a gorm-backed admin provider.
 func NewAdminProvider(db *gorm.DB) *AdminProviderImpl {
 	return &AdminProviderImpl{db: db}

--- a/internal/service/user_provider.go
+++ b/internal/service/user_provider.go
@@ -16,6 +16,8 @@ type UserProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ UserProvider = (*UserProviderImpl)(nil)
+
 // NewUserProvider creates a gorm-backed UserProvider implementation.
 func NewUserProvider(db *gorm.DB) *UserProviderImpl {
 	return &UserProviderImpl{db: db}

--- a/internal/service/video/provider.go
+++ b/internal/service/video/provider.go
@@ -17,6 +17,8 @@ type VideoProviderImpl struct {
 	db *gorm.DB
 }
 
+var _ VideoProvider = (*VideoProviderImpl)(nil)
+
 // NewVideoProvider creates a gorm-backed VideoProvider implementation.
 func NewVideoProvider(db *gorm.DB) *VideoProviderImpl {
 	return &VideoProviderImpl{db: db}

--- a/internal/service/viewhistory/view_history_provider.go
+++ b/internal/service/viewhistory/view_history_provider.go
@@ -42,6 +42,8 @@ type ViewHistoryStoreImpl struct {
 	db *gorm.DB
 }
 
+var _ ViewHistoryStore = (*ViewHistoryStoreImpl)(nil)
+
 // NewViewHistoryStore creates a gorm-backed ViewHistoryStore implementation.
 func NewViewHistoryStore(db *gorm.DB) *ViewHistoryStoreImpl {
 	return &ViewHistoryStoreImpl{db: db}


### PR DESCRIPTION
…iders

- Add var _ XxxStore/Provider = (*Impl)(nil) for all 23 concrete data providers in the service layer (19 new + 4 from the comment/video/favorite rollout)
- Locks interface/impl sync at compile time: provider method-set drift now fails the build, keeping the service layer Kratos-shaped (biz depends on data interfaces) and ready for internal/data extraction
- Zero behavior change; build, vet, lint and full integration suite green