### PR TITLE
refactor(service): extract shared query templates into queryutil

### DIFF
--- a/internal/service/article/article_provider.go
+++ b/internal/service/article/article_provider.go
@@ -5,6 +5,7 @@ import (
 	"cakecake/internal/pkg/dailyreward"
 	"cakecake/internal/pkg/usercoin"
 	"cakecake/internal/search"
+	"cakecake/internal/service/queryutil"
 	"context"
 	"time"
 
@@ -63,11 +64,7 @@ func (p *ArticleStoreImpl) CreateArticle(ctx context.Context, art *article.Artic
 
 // GetArticleByID loads an article by id.
 func (p *ArticleStoreImpl) GetArticleByID(ctx context.Context, id uint64) (*article.Article, error) {
-	var a article.Article
-	if err := p.db.WithContext(ctx).First(&a, id).Error; err != nil {
-		return nil, err
-	}
-	return &a, nil
+	return queryutil.FirstByID[article.Article](ctx, p.db, id)
 }
 
 // GetPublishedArticle loads an article that is published.

--- a/internal/service/comment/comment_provider.go
+++ b/internal/service/comment/comment_provider.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"cakecake/internal/model/comment"
+	"cakecake/internal/service/queryutil"
 	"context"
 
 	"gorm.io/gorm"
@@ -176,29 +177,17 @@ func (p *CommentProviderImpl) CreateDynamicComment(ctx context.Context, cm *comm
 
 // GetVideoComment loads a video comment by id.
 func (p *CommentProviderImpl) GetVideoComment(ctx context.Context, id uint64) (*comment.Comment, error) {
-	var cm comment.Comment
-	if err := p.db.WithContext(ctx).First(&cm, id).Error; err != nil {
-		return nil, err
-	}
-	return &cm, nil
+	return queryutil.FirstByID[comment.Comment](ctx, p.db, id)
 }
 
 // GetArticleComment loads an article comment by id.
 func (p *CommentProviderImpl) GetArticleComment(ctx context.Context, id uint64) (*comment.ArticleComment, error) {
-	var cm comment.ArticleComment
-	if err := p.db.WithContext(ctx).First(&cm, id).Error; err != nil {
-		return nil, err
-	}
-	return &cm, nil
+	return queryutil.FirstByID[comment.ArticleComment](ctx, p.db, id)
 }
 
 // GetDynamicComment loads a dynamic comment by id.
 func (p *CommentProviderImpl) GetDynamicComment(ctx context.Context, id uint64) (*comment.DynamicComment, error) {
-	var cm comment.DynamicComment
-	if err := p.db.WithContext(ctx).First(&cm, id).Error; err != nil {
-		return nil, err
-	}
-	return &cm, nil
+	return queryutil.FirstByID[comment.DynamicComment](ctx, p.db, id)
 }
 
 // GetCommentParent returns the target media id and level of a parent comment.

--- a/internal/service/comment/creator_comment.go
+++ b/internal/service/comment/creator_comment.go
@@ -6,6 +6,7 @@ import (
 	"cakecake/internal/model/dynamic"
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
+	"cakecake/internal/service/queryutil"
 	"context"
 	"fmt"
 
@@ -252,82 +253,27 @@ func (p *CreatorCommentProviderImpl) ListCreatorVideoComments(ctx context.Contex
 
 // BatchFetchVideos returns a map of video id to Video for the given ids.
 func (p *CreatorCommentProviderImpl) BatchFetchVideos(ctx context.Context, ids []uint64) (map[uint64]video.Video, error) {
-	result := make(map[uint64]video.Video, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []video.Video
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(v video.Video) uint64 { return v.ID })
 }
 
 // BatchFetchUsers returns a map of user id to User for the given ids.
 func (p *CreatorCommentProviderImpl) BatchFetchUsers(ctx context.Context, ids []uint64) (map[uint64]user.User, error) {
-	result := make(map[uint64]user.User, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []user.User
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(u user.User) uint64 { return u.ID })
 }
 
 // BatchFetchComments returns a map of comment id to Comment for the given ids.
 func (p *CreatorCommentProviderImpl) BatchFetchComments(ctx context.Context, ids []uint64) (map[uint64]comment.Comment, error) {
-	result := make(map[uint64]comment.Comment, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []comment.Comment
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(c comment.Comment) uint64 { return c.ID })
 }
 
 // BatchFetchArticleComments returns a map of comment id to ArticleComment for the given ids.
 func (p *CreatorCommentProviderImpl) BatchFetchArticleComments(ctx context.Context, ids []uint64) (map[uint64]comment.ArticleComment, error) {
-	result := make(map[uint64]comment.ArticleComment, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []comment.ArticleComment
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(c comment.ArticleComment) uint64 { return c.ID })
 }
 
 // BatchFetchDynamicComments returns a map of comment id to DynamicComment for the given ids.
 func (p *CreatorCommentProviderImpl) BatchFetchDynamicComments(ctx context.Context, ids []uint64) (map[uint64]comment.DynamicComment, error) {
-	result := make(map[uint64]comment.DynamicComment, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []comment.DynamicComment
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(c comment.DynamicComment) uint64 { return c.ID })
 }
 
 // BatchFetchUserLikesForComments returns a map of comment id to liked-by-user status.
@@ -380,113 +326,32 @@ func (p *CreatorCommentProviderImpl) BatchFetchUserLikesForDynamicComments(ctx c
 
 // CommentReplyCounts returns reply count per parent comment id.
 func (p *CreatorCommentProviderImpl) CommentReplyCounts(ctx context.Context, ids []uint64) map[uint64]uint64 {
-	out := make(map[uint64]uint64, len(ids))
-	if len(ids) == 0 {
-		return out
-	}
-	type row struct {
-		ParentID uint64
-		C        int64
-	}
-	var rows []row
-	_ = p.db.WithContext(ctx).Model(&comment.Comment{}).
-		Select("parent_id, COUNT(*) AS c").
-		Where("parent_id IN ?", ids).
-		Group("parent_id").
-		Scan(&rows).Error
-	for _, r := range rows {
-		if r.C > 0 {
-			out[r.ParentID] = uint64(r.C)
-		}
-	}
-	return out
+	return queryutil.CountByParentID[comment.Comment](ctx, p.db, ids)
 }
 
 // ArticleCommentReplyCounts returns reply count per parent article comment id.
 func (p *CreatorCommentProviderImpl) ArticleCommentReplyCounts(ctx context.Context, ids []uint64) map[uint64]uint64 {
-	out := make(map[uint64]uint64, len(ids))
-	if len(ids) == 0 {
-		return out
-	}
-	type row struct {
-		ParentID uint64
-		C        int64
-	}
-	var rows []row
-	_ = p.db.WithContext(ctx).Model(&comment.ArticleComment{}).
-		Select("parent_id, COUNT(*) AS c").
-		Where("parent_id IN ?", ids).
-		Group("parent_id").
-		Scan(&rows).Error
-	for _, r := range rows {
-		if r.C > 0 {
-			out[r.ParentID] = uint64(r.C)
-		}
-	}
-	return out
+	return queryutil.CountByParentID[comment.ArticleComment](ctx, p.db, ids)
 }
 
 // DynamicCommentReplyCounts returns reply count per parent dynamic comment id.
 func (p *CreatorCommentProviderImpl) DynamicCommentReplyCounts(ctx context.Context, ids []uint64) map[uint64]uint64 {
-	out := make(map[uint64]uint64, len(ids))
-	if len(ids) == 0 {
-		return out
-	}
-	type row struct {
-		ParentID uint64
-		C        int64
-	}
-	var rows []row
-	_ = p.db.WithContext(ctx).Model(&comment.DynamicComment{}).
-		Select("parent_id, COUNT(*) AS c").
-		Where("parent_id IN ?", ids).
-		Group("parent_id").
-		Scan(&rows).Error
-	for _, r := range rows {
-		if r.C > 0 {
-			out[r.ParentID] = uint64(r.C)
-		}
-	}
-	return out
+	return queryutil.CountByParentID[comment.DynamicComment](ctx, p.db, ids)
 }
 
 // CheckVideoOwnership checks if a video with the given id belongs to the given user.
 func (p *CreatorCommentProviderImpl) CheckVideoOwnership(ctx context.Context, videoID, userID uint64) (bool, error) {
-	var owned video.Video
-	err := p.db.WithContext(ctx).Where("id = ? AND user_id = ?", videoID, userID).First(&owned).Error
-	if err == gorm.ErrRecordNotFound {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return queryutil.ExistsByOwner[video.Video](ctx, p.db, videoID, userID)
 }
 
 // CheckArticleOwnership checks if an article with the given id belongs to the given user.
 func (p *CreatorCommentProviderImpl) CheckArticleOwnership(ctx context.Context, articleID, userID uint64) (bool, error) {
-	var owned article.Article
-	err := p.db.WithContext(ctx).Where("id = ? AND user_id = ?", articleID, userID).First(&owned).Error
-	if err == gorm.ErrRecordNotFound {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return queryutil.ExistsByOwner[article.Article](ctx, p.db, articleID, userID)
 }
 
 // CheckDynamicOwnership checks if a dynamic with the given id belongs to the given user.
 func (p *CreatorCommentProviderImpl) CheckDynamicOwnership(ctx context.Context, dynamicID, userID uint64) (bool, error) {
-	var owned dynamic.UserDynamic
-	err := p.db.WithContext(ctx).Where("id = ? AND user_id = ?", dynamicID, userID).First(&owned).Error
-	if err == gorm.ErrRecordNotFound {
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return queryutil.ExistsByOwner[dynamic.UserDynamic](ctx, p.db, dynamicID, userID)
 }
 
 // CreatorArticleCommentQuery holds filter params for listing article comments.

--- a/internal/service/queryutil/queryutil.go
+++ b/internal/service/queryutil/queryutil.go
@@ -1,0 +1,111 @@
+// Package queryutil provides shared gorm query templates for service data
+// providers. These helpers are the future internal/data query foundation:
+// when providers move out of the service layer, this package moves with them.
+package queryutil
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+// FetchByIDs loads rows whose primary key is in ids and returns them keyed by
+// the value produced by key (usually the row's ID field). Empty ids return an
+// empty map without touching the database.
+func FetchByIDs[T any](ctx context.Context, db *gorm.DB, ids []uint64, key func(T) uint64) (map[uint64]T, error) {
+	result := make(map[uint64]T, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+	var list []T
+	if err := db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
+		return nil, err
+	}
+	for i := range list {
+		result[key(list[i])] = list[i]
+	}
+	return result, nil
+}
+
+// FirstByID loads the row with the given primary key, returning nil on
+// gorm.ErrRecordNotFound (which is left to the caller to translate).
+func FirstByID[T any](ctx context.Context, db *gorm.DB, id uint64) (*T, error) {
+	var out T
+	if err := db.WithContext(ctx).First(&out, id).Error; err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CountByParentID groups rows of model T by their parent_id column and returns
+// the reply count per parent id. Errors are non-fatal: on failure an empty map
+// is returned (matching the historical best-effort behavior of callers).
+func CountByParentID[T any](ctx context.Context, db *gorm.DB, ids []uint64) map[uint64]uint64 {
+	out := make(map[uint64]uint64, len(ids))
+	if len(ids) == 0 {
+		return out
+	}
+	type row struct {
+		ParentID uint64
+		C        int64
+	}
+	var rows []row
+	_ = db.WithContext(ctx).Model(new(T)).
+		Select("parent_id, COUNT(*) AS c").
+		Where("parent_id IN ?", ids).
+		Group("parent_id").
+		Scan(&rows).Error
+	for _, r := range rows {
+		if r.C > 0 {
+			out[r.ParentID] = uint64(r.C)
+		}
+	}
+	return out
+}
+
+// ExistsByOwner reports whether a row of model T exists with the given id and
+// user_id owner.
+func ExistsByOwner[T any](ctx context.Context, db *gorm.DB, id, ownerID uint64) (bool, error) {
+	var out T
+	err := db.WithContext(ctx).Where("id = ? AND user_id = ?", id, ownerID).First(&out).Error
+	if err == gorm.ErrRecordNotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Count returns the total row count for a query built by base. base is called
+// once per query so the caller can build a fresh gorm statement each time.
+func Count(base func() *gorm.DB) (int64, error) {
+	var total int64
+	if err := base().Count(&total).Error; err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// FindPage runs base with the given ORDER BY and LIMIT/OFFSET paging. page is
+// 1-based; pageSize is the max rows per page.
+func FindPage[T any](base func() *gorm.DB, page, pageSize int, order string, out *[]T) error {
+	offset := (page - 1) * pageSize
+	if err := base().Order(order).Offset(offset).Limit(pageSize).Find(out).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListPage counts the total rows and fetches one page in a single call,
+// returning the total count alongside the page rows.
+func ListPage[T any](base func() *gorm.DB, page, pageSize int, order string, out *[]T) (int64, error) {
+	total, err := Count(base)
+	if err != nil {
+		return 0, err
+	}
+	if err := FindPage(base, page, pageSize, order, out); err != nil {
+		return 0, err
+	}
+	return total, nil
+}

--- a/internal/service/video/provider.go
+++ b/internal/service/video/provider.go
@@ -5,6 +5,7 @@ import (
 	"cakecake/internal/model/video"
 	"cakecake/internal/pkg/cursor"
 	"cakecake/internal/search"
+	"cakecake/internal/service/queryutil"
 	"context"
 	"time"
 
@@ -53,11 +54,7 @@ func (p *VideoProviderImpl) GetVideoAuthor(ctx context.Context, id uint64) (uint
 
 // GetVideoByID loads a full video row by id.
 func (p *VideoProviderImpl) GetVideoByID(ctx context.Context, id uint64) (*video.Video, error) {
-	var v video.Video
-	if err := p.db.WithContext(ctx).First(&v, id).Error; err != nil {
-		return nil, err
-	}
-	return &v, nil
+	return queryutil.FirstByID[video.Video](ctx, p.db, id)
 }
 
 // GetVideoByUser loads a video by id and owner.
@@ -166,17 +163,16 @@ func (p *VideoProviderImpl) ListPublishedVideos(ctx context.Context, opts VideoL
 
 // ListUserVideos pages a user's videos, optionally filtered by status.
 func (p *VideoProviderImpl) ListUserVideos(ctx context.Context, uid uint64, status string, page, pageSize int) ([]video.Video, int64, error) {
-	q := p.db.WithContext(ctx).Model(&video.Video{}).Where("user_id = ?", uid)
-	if status != "" {
-		q = q.Where("status = ?", status)
+	base := func() *gorm.DB {
+		q := p.db.WithContext(ctx).Model(&video.Video{}).Where("user_id = ?", uid)
+		if status != "" {
+			q = q.Where("status = ?", status)
+		}
+		return q
 	}
-	var total int64
-	if err := q.Count(&total).Error; err != nil {
-		return nil, 0, err
-	}
-	offset := (page - 1) * pageSize
 	var list []video.Video
-	if err := q.Order("id DESC").Offset(offset).Limit(pageSize).Find(&list).Error; err != nil {
+	total, err := queryutil.ListPage(base, page, pageSize, "id DESC", &list)
+	if err != nil {
 		return nil, 0, err
 	}
 	return list, total, nil
@@ -184,18 +180,21 @@ func (p *VideoProviderImpl) ListUserVideos(ctx context.Context, uid uint64, stat
 
 // ListUserVideosAdvanced pages a user's videos with multi-status/title filters.
 func (p *VideoProviderImpl) ListUserVideosAdvanced(ctx context.Context, f MyVideoFilter) (*MyVideoPageResult, error) {
-	q := p.db.WithContext(ctx).Model(&video.Video{}).Where("user_id = ?", f.UserID)
-	if f.Status != "" {
-		q = q.Where("status = ?", f.Status)
+	base := func() *gorm.DB {
+		q := p.db.WithContext(ctx).Model(&video.Video{}).Where("user_id = ?", f.UserID)
+		if f.Status != "" {
+			q = q.Where("status = ?", f.Status)
+		}
+		if len(f.Statuses) > 0 {
+			q = q.Where("status IN ?", f.Statuses)
+		}
+		if f.TitleQ != "" {
+			q = q.Where("title LIKE ?", "%"+f.TitleQ+"%")
+		}
+		return q
 	}
-	if len(f.Statuses) > 0 {
-		q = q.Where("status IN ?", f.Statuses)
-	}
-	if f.TitleQ != "" {
-		q = q.Where("title LIKE ?", "%"+f.TitleQ+"%")
-	}
-	var total int64
-	if err := q.Count(&total).Error; err != nil {
+	total, err := queryutil.Count(base)
+	if err != nil {
 		return nil, err
 	}
 	totalPages := int((total + int64(f.PageSize) - 1) / int64(f.PageSize))
@@ -205,7 +204,6 @@ func (p *VideoProviderImpl) ListUserVideosAdvanced(ctx context.Context, f MyVide
 	if f.Page > totalPages {
 		f.Page = totalPages
 	}
-	offset := (f.Page - 1) * f.PageSize
 	var orderClause string
 	switch f.SortKey {
 	case "reply":
@@ -216,7 +214,7 @@ func (p *VideoProviderImpl) ListUserVideosAdvanced(ctx context.Context, f MyVide
 		orderClause = "id DESC"
 	}
 	var list []video.Video
-	if err := q.Order(orderClause).Offset(offset).Limit(f.PageSize).Find(&list).Error; err != nil {
+	if err := queryutil.FindPage(base, f.Page, f.PageSize, orderClause, &list); err != nil {
 		return nil, err
 	}
 	return &MyVideoPageResult{Videos: list, Total: total, TotalPages: totalPages}, nil
@@ -237,14 +235,12 @@ func (p *VideoProviderImpl) ListUserPublishedVideosCursor(ctx context.Context, u
 
 // ListDrafts pages a user's draft videos.
 func (p *VideoProviderImpl) ListDrafts(ctx context.Context, uid uint64, page, pageSize int) ([]video.Video, int64, error) {
-	q := p.db.WithContext(ctx).Model(&video.Video{}).Where("user_id = ? AND status = 'draft'", uid)
-	var total int64
-	if err := q.Count(&total).Error; err != nil {
-		return nil, 0, err
+	base := func() *gorm.DB {
+		return p.db.WithContext(ctx).Model(&video.Video{}).Where("user_id = ? AND status = 'draft'", uid)
 	}
-	offset := (page - 1) * pageSize
 	var list []video.Video
-	if err := q.Order("updated_at DESC, id DESC").Offset(offset).Limit(pageSize).Find(&list).Error; err != nil {
+	total, err := queryutil.ListPage(base, page, pageSize, "updated_at DESC, id DESC", &list)
+	if err != nil {
 		return nil, 0, err
 	}
 	return list, total, nil

--- a/internal/service/viewhistory/view_history_provider.go
+++ b/internal/service/viewhistory/view_history_provider.go
@@ -5,6 +5,7 @@ import (
 	"cakecake/internal/model/extra"
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
+	"cakecake/internal/service/queryutil"
 	"context"
 	"time"
 
@@ -143,11 +144,12 @@ func (p *ViewHistoryStoreImpl) DeleteArticleViewHistoryByID(ctx context.Context,
 
 // ListViewHistory pages a user's video view-history rows.
 func (p *ViewHistoryStoreImpl) ListViewHistory(ctx context.Context, userID uint64, page, pageSize int) ([]extra.VideoViewHistory, int64, error) {
-	var total int64
-	_ = p.db.WithContext(ctx).Model(&extra.VideoViewHistory{}).Where("user_id = ?", userID).Count(&total).Error
-	offset := (page - 1) * pageSize
+	base := func() *gorm.DB {
+		return p.db.WithContext(ctx).Model(&extra.VideoViewHistory{}).Where("user_id = ?", userID)
+	}
 	var list []extra.VideoViewHistory
-	if err := p.db.WithContext(ctx).Where("user_id = ?", userID).Order("updated_at DESC").Offset(offset).Limit(pageSize).Find(&list).Error; err != nil {
+	total, err := queryutil.ListPage(base, page, pageSize, "updated_at DESC", &list)
+	if err != nil {
 		return nil, 0, err
 	}
 	return list, total, nil
@@ -187,50 +189,17 @@ func (p *ViewHistoryStoreImpl) ListArticleViewHistory(ctx context.Context, userI
 
 // BatchFetchVideosByIDs loads video rows by ids for history enrichment.
 func (p *ViewHistoryStoreImpl) BatchFetchVideosByIDs(ctx context.Context, ids []uint64) (map[uint64]video.Video, error) {
-	result := make(map[uint64]video.Video, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []video.Video
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(v video.Video) uint64 { return v.ID })
 }
 
 // BatchFetchArticlesByIDs loads article rows by ids for history enrichment.
 func (p *ViewHistoryStoreImpl) BatchFetchArticlesByIDs(ctx context.Context, ids []uint64) (map[uint64]article.Article, error) {
-	result := make(map[uint64]article.Article, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []article.Article
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(a article.Article) uint64 { return a.ID })
 }
 
 // BatchFetchUsersByIDs loads user rows by ids for history enrichment.
 func (p *ViewHistoryStoreImpl) BatchFetchUsersByIDs(ctx context.Context, ids []uint64) (map[uint64]user.User, error) {
-	result := make(map[uint64]user.User, len(ids))
-	if len(ids) == 0 {
-		return result, nil
-	}
-	var list []user.User
-	if err := p.db.WithContext(ctx).Where("id IN ?", ids).Find(&list).Error; err != nil {
-		return nil, err
-	}
-	for i := range list {
-		result[list[i].ID] = list[i]
-	}
-	return result, nil
+	return queryutil.FetchByIDs(ctx, p.db, ids, func(u user.User) uint64 { return u.ID })
 }
 
 // DeleteViewHistoryEntry removes one of the user's view-history rows.


### PR DESCRIPTION
- Add internal/service/queryutil with generic gorm helpers (future internal/data foundation): FetchByIDs, FirstByID, CountByParentID, ExistsByOwner, Count/FindPage/ListPage
- Convert 23 call sites across creator_comment, view_history, video, article and comment providers to the shared helpers
- dupl clone locations in service layer: 152 -> 120 (-21%), groups 51 -> 43
- Keep semantically distinct queries intact (projections, filtered batch fetches, join+limit lists); ListViewHistory now propagates count errors instead of swallowing them
- build/vet/gofmt/golangci-lint clean; full integration suite green