### PR TITLE
refactor(client): remove gorm from transport contracts via dbtx.Tx

### DIFF
--- a/internal/client/ArticleSvc.go
+++ b/internal/client/ArticleSvc.go
@@ -4,15 +4,15 @@ package client
 
 import (
 	article "cakecake/internal/model/article"
+	dbtx "cakecake/internal/pkg/dbtx"
 	servicearticle "cakecake/internal/service/article"
 	context "context"
-	gorm "gorm.io/gorm"
 )
 
 // ArticleSvc is the client-side contract for cakecake/internal/service/article.ArticleService.
 // Local implementation: servicearticle.ArticleService (see the assertion below). A future gRPC client must implement this interface.
 type ArticleSvc interface {
-	AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 	AdminListArticles(ctx context.Context, statuses []string, titleQ string, page int, pageSize int) (*servicearticle.AdminListArticlesResult, error)
 	AdminUpdateArticle(ctx context.Context, id uint64, updates map[string]interface{}) error
 	BatchArticleEngagementByViewer(ctx context.Context, viewerID uint64, articleIDs []uint64) map[uint64]*servicearticle.ArticleEngagement

--- a/internal/client/DynamicSvc.go
+++ b/internal/client/DynamicSvc.go
@@ -4,15 +4,15 @@ package client
 
 import (
 	dynamic "cakecake/internal/model/dynamic"
+	dbtx "cakecake/internal/pkg/dbtx"
 	servicedynamic "cakecake/internal/service/dynamic"
 	context "context"
-	gorm "gorm.io/gorm"
 )
 
 // DynamicSvc is the client-side contract for cakecake/internal/service/dynamic.DynamicService.
 // Local implementation: servicedynamic.DynamicService (see the assertion below). A future gRPC client must implement this interface.
 type DynamicSvc interface {
-	AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 	AdminListDynamics(ctx context.Context, q string, page int, pageSize int) (*servicedynamic.AdminListDynamicsResult, error)
 	BatchCheckLiked(ctx context.Context, viewerID uint64, dynamicIDs []uint64) map[uint64]bool
 	CountUserDynamics(ctx context.Context, userID uint64) (int64, error)

--- a/internal/client/UserSvc.go
+++ b/internal/client/UserSvc.go
@@ -4,9 +4,9 @@ package client
 
 import (
 	user "cakecake/internal/model/user"
+	dbtx "cakecake/internal/pkg/dbtx"
 	serviceuser "cakecake/internal/service/user"
 	context "context"
-	gorm "gorm.io/gorm"
 	time "time"
 )
 
@@ -15,7 +15,7 @@ import (
 type UserSvc interface {
 	BatchGetUsers(ctx context.Context, userIDs []uint64) map[uint64]*user.User
 	EnsureCakeID(ctx context.Context, u *user.User) error
-	FinalizeDeletion(ctx context.Context, uid uint64, fn func(tx *gorm.DB) error) error
+	FinalizeDeletion(ctx context.Context, uid uint64, fn func(tx dbtx.Tx) error) error
 	GetMe(ctx context.Context, userID uint64) (*serviceuser.UserProfile, error)
 	GetPasswordHash(ctx context.Context, userID uint64) (string, error)
 	GetPrivacySettings(ctx context.Context, userID uint64) (*user.User, error)

--- a/internal/client/VideoSvc.go
+++ b/internal/client/VideoSvc.go
@@ -4,15 +4,15 @@ package client
 
 import (
 	video "cakecake/internal/model/video"
+	dbtx "cakecake/internal/pkg/dbtx"
 	servicevideo "cakecake/internal/service/video"
 	context "context"
-	gorm "gorm.io/gorm"
 )
 
 // VideoSvc is the client-side contract for cakecake/internal/service/video.VideoService.
 // Local implementation: servicevideo.VideoService (see the assertion below). A future gRPC client must implement this interface.
 type VideoSvc interface {
-	AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 	AdminListVideos(ctx context.Context, statuses []string, titleQ string, page int, pageSize int) (*servicevideo.AdminListVideosResult, error)
 	AdminUpdateVideo(ctx context.Context, id uint64, updates map[string]interface{}) error
 	CountMyVideosByStatus(uid uint64) map[string]int64
@@ -20,7 +20,7 @@ type VideoSvc interface {
 	CountZoneVideos(zoneParent string) int64
 	CreateVideoRecord(ctx context.Context, v *video.Video) error
 	DeleteVideoByID(ctx context.Context, id uint64) error
-	DeleteVideoWithCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	DeleteVideoWithCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 	EnqueueTranscode(ctx context.Context, videoID uint64, rawPath string, coverPath string) error
 	FFprobeExe() string
 	GetPublishedVideo(ctx context.Context, id uint64) (*video.Video, error)

--- a/internal/handler/account_deletion.go
+++ b/internal/handler/account_deletion.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"time"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 
 	"cakecake/internal/errcode"
 	"cakecake/internal/middleware"
@@ -34,7 +35,7 @@ func deletionCoolingDays() int {
 	return 7 + int(n.Int64())
 }
 
-func deleteOwnedVideosAndRelated(tx *gorm.DB, uid uint64) ([]video.Video, error) {
+func deleteOwnedVideosAndRelated(tx dbtx.Tx, uid uint64) ([]video.Video, error) {
 	var videos []video.Video
 	if err := tx.Where("user_id = ?", uid).Find(&videos).Error; err != nil {
 		return nil, err
@@ -47,7 +48,7 @@ func deleteOwnedVideosAndRelated(tx *gorm.DB, uid uint64) ([]video.Video, error)
 	return videos, nil
 }
 
-func finalizeUserAnonymization(tx *gorm.DB, uid uint64) ([]video.Video, error) {
+func finalizeUserAnonymization(tx dbtx.Tx, uid uint64) ([]video.Video, error) {
 	if err := tx.Where("recipient_id = ?", uid).Delete(&notification.Notification{}).Error; err != nil {
 		return nil, err
 	}
@@ -97,7 +98,7 @@ func maybeFinalizeAccountDeletion(ctx context.Context, a *API, uid uint64) error
 		return nil
 	}
 	var removedVideos []video.Video
-	err = a.UserSvc.FinalizeDeletion(ctx, uid, func(tx *gorm.DB) error {
+	err = a.UserSvc.FinalizeDeletion(ctx, uid, func(tx dbtx.Tx) error {
 		var innerErr error
 		removedVideos, innerErr = finalizeUserAnonymization(tx, uid)
 		return innerErr

--- a/internal/handler/admin_article.go
+++ b/internal/handler/admin_article.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 
 	"cakecake/internal/errcode"
 	"cakecake/internal/middleware"
@@ -263,7 +264,7 @@ func (a *API) AdminDeleteArticle(c *gin.Context) {
 		resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
 		return
 	}
-	if err := a.ArticleSvc.AdminDeleteArticleCascade(c.Request.Context(), id, func(tx *gorm.DB) error {
+	if err := a.ArticleSvc.AdminDeleteArticleCascade(c.Request.Context(), id, func(tx dbtx.Tx) error {
 		return deleteArticleCascade(tx, id)
 	}); err != nil {
 		a.Log.Error("admin delete article", zap.Error(err), zap.Uint64("article_id", id))

--- a/internal/handler/admin_dynamic.go
+++ b/internal/handler/admin_dynamic.go
@@ -9,9 +9,10 @@ import (
 	"strconv"
 	"strings"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 
 	"cakecake/internal/errcode"
 	"cakecake/internal/middleware"
@@ -148,7 +149,7 @@ func (a *API) AdminDeleteDynamic(c *gin.Context) {
 		resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
 		return
 	}
-	if err := a.DynamicSvc.AdminDeleteDynamicCascade(c.Request.Context(), id, func(tx *gorm.DB) error {
+	if err := a.DynamicSvc.AdminDeleteDynamicCascade(c.Request.Context(), id, func(tx dbtx.Tx) error {
 		return deleteUserDynamicCascade(tx, id)
 	}); err != nil {
 		a.Log.Error("admin delete dynamic", zap.Error(err), zap.Uint64("dynamic_id", id))

--- a/internal/handler/admin_video.go
+++ b/internal/handler/admin_video.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 
 	"cakecake/internal/errcode"
 	"cakecake/internal/middleware"
@@ -266,7 +267,7 @@ func (a *API) AdminDeleteVideo(c *gin.Context) {
 		return
 	}
 	removeVideoDraftFiles(*v)
-	if err := a.VideoSvc.AdminDeleteVideoCascade(c.Request.Context(), id, func(tx *gorm.DB) error {
+	if err := a.VideoSvc.AdminDeleteVideoCascade(c.Request.Context(), id, func(tx dbtx.Tx) error {
 		return deleteVideoCascade(tx, id)
 	}); err != nil {
 		a.Log.Error("admin delete video", zap.Error(err), zap.Uint64("video_id", id))

--- a/internal/handler/article.go
+++ b/internal/handler/article.go
@@ -19,10 +19,11 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 )
 
 const (
@@ -434,7 +435,7 @@ func (a *API) ListMyArticles(c *gin.Context) {
 }
 
 // deleteArticleCascade removes one article and related engagement rows.
-func deleteArticleCascade(tx *gorm.DB, articleID uint64) error {
+func deleteArticleCascade(tx dbtx.Tx, articleID uint64) error {
 	var cids []uint64
 	if err := tx.Model(&comment.ArticleComment{}).Where("article_id = ?", articleID).Pluck("id", &cids).Error; err != nil {
 		return err

--- a/internal/handler/user_dynamic.go
+++ b/internal/handler/user_dynamic.go
@@ -14,10 +14,11 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 
 	"cakecake/internal/errcode"
 	"cakecake/internal/middleware"
@@ -443,7 +444,7 @@ func (a *API) ToggleDynamicLike(c *gin.Context) {
 	}
 }
 
-func deleteUserDynamicCascade(tx *gorm.DB, id uint64) error {
+func deleteUserDynamicCascade(tx dbtx.Tx, id uint64) error {
 	var cids []uint64
 	_ = tx.Model(&comment.DynamicComment{}).Where("dynamic_id = ?", id).Pluck("id", &cids).Error
 	if len(cids) > 0 {

--- a/internal/handler/video_manage.go
+++ b/internal/handler/video_manage.go
@@ -18,10 +18,11 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"cakecake/internal/pkg/dbtx"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 )
 
 func manuscriptVideoStatusToDB(st string) string {
@@ -375,7 +376,7 @@ type videoPlaybackResponse struct {
 }
 
 // deleteVideoCascade removes one video and its comments, likes, danmaku (same package as account deletion).
-func deleteVideoCascade(tx *gorm.DB, videoID uint64) error {
+func deleteVideoCascade(tx dbtx.Tx, videoID uint64) error {
 	var cids []uint64
 	if err := tx.Model(&comment.Comment{}).Where("video_id = ?", videoID).Pluck("id", &cids).Error; err != nil {
 		return err

--- a/internal/pkg/dbtx/dbtx.go
+++ b/internal/pkg/dbtx/dbtx.go
@@ -1,0 +1,22 @@
+// Package dbtx defines the minimal transaction surface exposed to
+// cascade-delete callbacks. It keeps persistence types out of transport
+// contracts (internal/client) so the client layer can later map to gRPC
+// without importing gorm.
+package dbtx
+
+import "gorm.io/gorm"
+
+// Tx is the subset of *gorm.DB methods used by cascade-delete callbacks.
+// gorm.DB satisfies it structurally; service providers pass their *gorm.DB
+// transaction directly.
+type Tx interface {
+	Model(value interface{}) *gorm.DB
+	Where(query interface{}, args ...interface{}) *gorm.DB
+	Pluck(column string, dest interface{}) *gorm.DB
+	Find(dest interface{}, conds ...interface{}) *gorm.DB
+	Delete(value interface{}, conds ...interface{}) *gorm.DB
+	Updates(values interface{}) *gorm.DB
+}
+
+// Compile-time proof that gorm.DB implements Tx.
+var _ Tx = (*gorm.DB)(nil)

--- a/internal/service/article/article.go
+++ b/internal/service/article/article.go
@@ -4,6 +4,7 @@ import (
 	"cakecake/internal/model/article"
 	"cakecake/internal/model/comment"
 	"cakecake/internal/model/extra"
+	"cakecake/internal/pkg/dbtx"
 	"context"
 	"errors"
 	"fmt"
@@ -330,6 +331,6 @@ func (s *ArticleService) AdminListArticles(ctx context.Context, statuses []strin
 }
 
 // AdminDeleteArticleCascade deletes an article within a transaction with a custom function.
-func (s *ArticleService) AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (s *ArticleService) AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	return s.store.AdminDeleteArticleCascade(ctx, id, fn)
 }

--- a/internal/service/article/article_provider.go
+++ b/internal/service/article/article_provider.go
@@ -3,6 +3,7 @@ package article
 import (
 	"cakecake/internal/model/article"
 	"cakecake/internal/pkg/dailyreward"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/pkg/usercoin"
 	"cakecake/internal/search"
 	"cakecake/internal/service/queryutil"
@@ -41,7 +42,7 @@ type ArticleStore interface {
 	GrantCoinExp(uid uint64, before, after int) error
 	CountByStatus(ctx context.Context, status string) (int64, error)
 	AdminListArticles(ctx context.Context, statuses []string, titleQ string, page, pageSize int) (*AdminListArticlesResult, error)
-	AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 	PublishArticle(ctx context.Context, esc *search.Client, log *zap.Logger, articleID uint64, adminID *uint64) error
 }
 
@@ -460,7 +461,7 @@ func (p *ArticleStoreImpl) PublishArticle(ctx context.Context, esc *search.Clien
 }
 
 // AdminDeleteArticleCascade runs the cascade delete callback inside a transaction.
-func (p *ArticleStoreImpl) AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (p *ArticleStoreImpl) AdminDeleteArticleCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := fn(tx); err != nil {
 			return err

--- a/internal/service/article/article_test.go
+++ b/internal/service/article/article_test.go
@@ -3,6 +3,7 @@ package article
 import (
 	"cakecake/internal/model/article"
 	"cakecake/internal/model/comment"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/service/servicetest"
 	"context"
 	"testing"
@@ -171,7 +172,7 @@ func TestArticleService_AdminAndDelete(t *testing.T) {
 
 	// Admin delete cascade callback.
 	called := false
-	require.NoError(t, s.AdminDeleteArticleCascade(ctx, 11, func(tx *gorm.DB) error {
+	require.NoError(t, s.AdminDeleteArticleCascade(ctx, 11, func(tx dbtx.Tx) error {
 		called = true
 		return nil
 	}))

--- a/internal/service/dynamic/dynamic.go
+++ b/internal/service/dynamic/dynamic.go
@@ -3,6 +3,7 @@ package dynamic
 import (
 	"cakecake/internal/model/comment"
 	"cakecake/internal/model/dynamic"
+	"cakecake/internal/pkg/dbtx"
 	"context"
 
 	"github.com/redis/go-redis/v9"
@@ -36,7 +37,7 @@ type DynamicStore interface {
 	ListUserDynamicsCursor(ctx context.Context, userID uint64, cursorID uint64, limit int) ([]dynamic.UserDynamic, error)
 	ListMyDynamicsAdvanced(ctx context.Context, f MyDynamicFilter) (*MyDynamicPageResult, error)
 	AdminListDynamics(ctx context.Context, q string, page, pageSize int) (*AdminListDynamicsResult, error)
-	AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 }
 
 // DynamicStoreImpl implements DynamicStore using *gorm.DB (Phase 1 monolith).
@@ -252,7 +253,7 @@ func (p *DynamicStoreImpl) AdminListDynamics(ctx context.Context, q string, page
 }
 
 // AdminDeleteDynamicCascade deletes a dynamic within a transaction with a custom function.
-func (p *DynamicStoreImpl) AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (p *DynamicStoreImpl) AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return fn(tx)
 	})
@@ -319,6 +320,6 @@ func (s *DynamicService) AdminListDynamics(ctx context.Context, q string, page, 
 }
 
 // AdminDeleteDynamicCascade deletes a dynamic within a transaction with a custom function.
-func (s *DynamicService) AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (s *DynamicService) AdminDeleteDynamicCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	return s.store.AdminDeleteDynamicCascade(ctx, id, fn)
 }

--- a/internal/service/dynamic/dynamic_test.go
+++ b/internal/service/dynamic/dynamic_test.go
@@ -3,6 +3,7 @@ package dynamic
 import (
 	"cakecake/internal/model/comment"
 	"cakecake/internal/model/dynamic"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/service/servicetest"
 	"context"
 	"testing"
@@ -141,7 +142,7 @@ func TestDynamicService_AdvancedAndAdmin(t *testing.T) {
 	require.Equal(t, int64(3), adminRes.Total)
 
 	called := false
-	require.NoError(t, s.AdminDeleteDynamicCascade(ctx, 1, func(tx *gorm.DB) error {
+	require.NoError(t, s.AdminDeleteDynamicCascade(ctx, 1, func(tx dbtx.Tx) error {
 		called = true
 		return nil
 	}))

--- a/internal/service/interfaces.go
+++ b/internal/service/interfaces.go
@@ -2,10 +2,9 @@ package service
 
 import (
 	"cakecake/internal/model/user"
+	"cakecake/internal/pkg/dbtx"
 	"context"
 	"time"
-
-	"gorm.io/gorm"
 )
 
 // Domain interfaces for Phase 1 microservice preparation
@@ -52,7 +51,7 @@ type UserProvider interface {
 	// MarkLogin records a daily login for a user.
 	MarkLogin(ctx context.Context, userID uint64) error
 	// WithTx runs fn inside a database transaction (Phase 1 monolith seam).
-	WithTx(ctx context.Context, fn func(tx *gorm.DB) error) error
+	WithTx(ctx context.Context, fn func(tx dbtx.Tx) error) error
 }
 
 // UserInfo is the cross-domain user data.

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"cakecake/internal/model/user"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/service"
 	"context"
 	"strings"
@@ -171,6 +172,6 @@ func (s *UserService) ListCoinLedger(ctx context.Context, userID uint64, since t
 }
 
 // FinalizeDeletion performs the final account anonymization within a transaction.
-func (s *UserService) FinalizeDeletion(ctx context.Context, uid uint64, fn func(tx *gorm.DB) error) error {
+func (s *UserService) FinalizeDeletion(ctx context.Context, uid uint64, fn func(tx dbtx.Tx) error) error {
 	return s.users.WithTx(ctx, fn)
 }

--- a/internal/service/user/user_test.go
+++ b/internal/service/user/user_test.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"cakecake/internal/model/user"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/service"
 	"cakecake/internal/service/servicetest"
 	"context"
@@ -126,7 +127,7 @@ func TestUserService_DeletionAndPrivacy(t *testing.T) {
 
 	// FinalizeDeletion commits the callback transaction.
 	committed := false
-	require.NoError(t, s.FinalizeDeletion(ctx, 1, func(tx *gorm.DB) error {
+	require.NoError(t, s.FinalizeDeletion(ctx, 1, func(tx dbtx.Tx) error {
 		committed = true
 		return nil
 	}))

--- a/internal/service/user_provider.go
+++ b/internal/service/user_provider.go
@@ -3,6 +3,7 @@ package service
 import (
 	"cakecake/internal/model/user"
 	"cakecake/internal/pkg/dailyreward"
+	"cakecake/internal/pkg/dbtx"
 	"context"
 	"time"
 
@@ -227,6 +228,8 @@ func (p *UserProviderImpl) MarkLogin(ctx context.Context, userID uint64) error {
 }
 
 // WithTx runs fn inside a transaction.
-func (p *UserProviderImpl) WithTx(ctx context.Context, fn func(tx *gorm.DB) error) error {
-	return p.db.WithContext(ctx).Transaction(fn)
+func (p *UserProviderImpl) WithTx(ctx context.Context, fn func(tx dbtx.Tx) error) error {
+	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(tx)
+	})
 }

--- a/internal/service/video/interfaces.go
+++ b/internal/service/video/interfaces.go
@@ -2,12 +2,12 @@ package video
 
 import (
 	"cakecake/internal/model/video"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/search"
 	"context"
 	"time"
 
 	"go.uber.org/zap"
-	"gorm.io/gorm"
 )
 
 // VideoProvider is the video domain boundary.
@@ -54,9 +54,9 @@ type VideoProvider interface {
 	// PublishVideo marks a video published and (re)indexes search. Monolith-phase flow.
 	PublishVideo(ctx context.Context, esc *search.Client, log *zap.Logger, videoID uint64, adminID *uint64) error
 	// AdminDeleteVideoCascade runs the cascade-delete callback inside a transaction.
-	AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error
+	AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error
 	// WithTx runs fn inside a database transaction (Phase 1 monolith seam).
-	WithTx(ctx context.Context, fn func(tx *gorm.DB) error) error
+	WithTx(ctx context.Context, fn func(tx dbtx.Tx) error) error
 
 	// AdminListVideos returns paginated videos with status/title filters for the admin panel.
 	AdminListVideos(ctx context.Context, statuses []string, titleQ string, page, pageSize int) (*AdminListVideosResult, error)

--- a/internal/service/video/provider.go
+++ b/internal/service/video/provider.go
@@ -4,6 +4,7 @@ import (
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
 	"cakecake/internal/pkg/cursor"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/search"
 	"cakecake/internal/service/queryutil"
 	"context"
@@ -349,15 +350,17 @@ func (p *VideoProviderImpl) PublishVideo(ctx context.Context, esc *search.Client
 }
 
 // AdminDeleteVideoCascade runs the cascade delete callback inside a transaction.
-func (p *VideoProviderImpl) AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (p *VideoProviderImpl) AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		return fn(tx)
 	})
 }
 
 // WithTx runs fn inside a transaction.
-func (p *VideoProviderImpl) WithTx(ctx context.Context, fn func(tx *gorm.DB) error) error {
-	return p.db.WithContext(ctx).Transaction(fn)
+func (p *VideoProviderImpl) WithTx(ctx context.Context, fn func(tx dbtx.Tx) error) error {
+	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(tx)
+	})
 }
 
 // AdminListVideos pages all videos for the admin panel with status/title filters.

--- a/internal/service/video/video.go
+++ b/internal/service/video/video.go
@@ -2,6 +2,7 @@ package video
 
 import (
 	"cakecake/internal/model/video"
+	"cakecake/internal/pkg/dbtx"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -126,12 +127,12 @@ func (s *VideoService) UpdateVideo(ctx context.Context, v *video.Video, updates 
 }
 
 // DeleteVideoWithCascade removes a video and its related data in a transaction.
-func (s *VideoService) DeleteVideoWithCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (s *VideoService) DeleteVideoWithCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	if fn != nil {
 		return s.videos.WithTx(ctx, fn)
 	}
 	// default: just delete the video record inside a transaction
-	return s.videos.WithTx(ctx, func(tx *gorm.DB) error {
+	return s.videos.WithTx(ctx, func(tx dbtx.Tx) error {
 		return tx.Delete(&video.Video{}, id).Error
 	})
 }
@@ -218,7 +219,7 @@ func (s *VideoService) AdminUpdateVideo(ctx context.Context, id uint64, updates 
 }
 
 // AdminDeleteVideoCascade deletes a video and cascades to related data within a transaction.
-func (s *VideoService) AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx *gorm.DB) error) error {
+func (s *VideoService) AdminDeleteVideoCascade(ctx context.Context, id uint64, fn func(tx dbtx.Tx) error) error {
 	return s.videos.AdminDeleteVideoCascade(ctx, id, fn)
 }
 

--- a/internal/service/video/video_test.go
+++ b/internal/service/video/video_test.go
@@ -2,6 +2,7 @@ package video
 
 import (
 	"cakecake/internal/model/video"
+	"cakecake/internal/pkg/dbtx"
 	"cakecake/internal/service/servicetest"
 	"context"
 	"testing"
@@ -129,7 +130,7 @@ func TestVideoService_MyVideosAndLike(t *testing.T) {
 
 	// Delete cascade with custom fn.
 	called := false
-	require.NoError(t, s.DeleteVideoWithCascade(ctx, 11, func(tx *gorm.DB) error {
+	require.NoError(t, s.DeleteVideoWithCascade(ctx, 11, func(tx dbtx.Tx) error {
 		called = true
 		return nil
 	}))
@@ -150,7 +151,7 @@ func TestVideoService_AdminList(t *testing.T) {
 	require.Equal(t, int64(1), adminRes.Total)
 	require.Zero(t, adminRes.PendingCount)
 	called := false
-	require.NoError(t, s.AdminDeleteVideoCascade(ctx, 10, func(tx *gorm.DB) error {
+	require.NoError(t, s.AdminDeleteVideoCascade(ctx, 10, func(tx dbtx.Tx) error {
 		called = true
 		return nil
 	}))


### PR DESCRIPTION
- Add internal/pkg/dbtx with a minimal Tx interface (Model/Where/Pluck/ Find/Delete/Updates) that gorm.DB satisfies structurally
- Change 5 client contract methods (AdminDeleteArticleCascade, AdminDeleteDynamicCascade, FinalizeDeletion, AdminDeleteVideoCascade, DeleteVideoWithCascade) from func(tx *gorm.DB) error to func(tx dbtx.Tx) error
- Thread dbtx.Tx through service impls, provider interfaces and handler cascade callbacks; internal/client no longer imports gorm (0 files)
- gRPC-readiness prerequisite: transport layer no longer names persistence types; comment's internal WithTx seam left untouched (out of scope)
- build/vet/gofmt/golangci-lint clean; full integration suite green