### PR TITLE
refactor: Kratos-ward layering guards, AgentService facade split, Gateway decomposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
             exit 1
           fi
 
+      - name: Check dependency directions
+        # Layering guard: handler->data, service->handler, client->gorm and
+        # model->service/data are forbidden (see scripts/check_deps.sh).
+        run: bash scripts/check_deps.sh
+
       - name: Run Go tests with coverage
         env:
           RABBITMQ_URL: amqp://guest:guest@localhost:5672/

--- a/internal/aigateway/gateway.go
+++ b/internal/aigateway/gateway.go
@@ -8,9 +8,6 @@ import (
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	"go.uber.org/zap"
-
-	"cakecake/internal/logger"
 )
 
 const defaultSystemPrompt = `你是 cakecake 站内 AI 助手。帮助用户了解本站功能。
@@ -67,40 +64,6 @@ func chatMsgToEntry(m ChatMessage) historyEntry {
 
 func entryToChatMsg(e historyEntry) ChatMessage {
 	return ChatMessage(e)
-}
-
-func (g *Gateway) historyKey(conversationID uint64) string {
-	p := g.HistoryPrefix
-	if p == "" {
-		p = "mb:agent:hist:"
-	}
-	return fmt.Sprintf("%s%d", p, conversationID)
-}
-
-// PersistHistory stores full message history for a conversation (used by
-// callers that assemble history outside the standard turn methods).
-func (g *Gateway) PersistHistory(ctx context.Context, conversationID uint64, msgs []ChatMessage) {
-	g.persistHistory(ctx, conversationID, msgs)
-}
-
-// BuildMessages loads ALL history (including tool messages) and appends user turn.
-func (g *Gateway) BuildMessages(ctx context.Context, conversationID uint64, userText string) ([]ChatMessage, error) {
-	msgs := []ChatMessage{{Role: "system", Content: g.systemPrompt()}}
-	if g.Redis != nil && conversationID > 0 {
-		raw, err := g.Redis.Get(ctx, g.historyKey(conversationID)).Bytes()
-		if err == nil && len(raw) > 0 {
-			var hist []historyEntry
-			if json.Unmarshal(raw, &hist) == nil {
-				for _, h := range hist {
-					if h.Role == "user" || h.Role == "assistant" || h.Role == "tool" {
-						msgs = append(msgs, entryToChatMsg(h))
-					}
-				}
-			}
-		}
-	}
-	msgs = append(msgs, ChatMessage{Role: "user", Content: userText})
-	return msgs, nil
 }
 
 // CompleteUserTurn is the simple text-only version (no tools).
@@ -299,117 +262,6 @@ func (g *Gateway) CompleteUserTurnWithToolsStream(
 	return "抱歉，操作超时，请稍后重试或简化问题。", nil
 }
 
-func (g *Gateway) executeToolCalls(ctx context.Context, calls []ToolCall, traceID string, round int) []ChatMessage {
-	type result struct {
-		msg ChatMessage
-	}
-	ch := make(chan result, len(calls))
-
-	for i, call := range calls {
-		go func(idx int, tc ToolCall) {
-			spanID := fmt.Sprintf("%s-r%d-t%d", traceID, round, idx)
-			parentSpanID := traceID
-
-			if g.OnToolCallStart != nil {
-				var raw json.RawMessage
-				if err := json.Unmarshal([]byte(tc.Function.Arguments), &raw); err != nil && logger.L != nil {
-					logger.L.Warn("aigateway: parse tool call args failed", zap.String("tool", tc.Function.Name), zap.Error(err))
-				}
-				g.OnToolCallStart(traceID, spanID, parentSpanID, tc.Function.Name, raw)
-			}
-
-			start := time.Now()
-			var res string
-			if g.ToolExec != nil {
-				r, err := g.ToolExec.Execute(ctx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
-				if err != nil {
-					res = fmt.Sprintf(`{"error": "%s"}`, err.Error())
-				} else {
-					res = r
-				}
-			} else {
-				res = `{"error": "tool executor not available"}`
-			}
-			duration := time.Since(start).Milliseconds()
-
-			if g.OnToolCallEnd != nil {
-				summary := res
-				if len(summary) > 80 {
-					summary = summary[:80] + "..."
-				}
-				g.OnToolCallEnd(traceID, spanID, tc.Function.Name, duration, summary)
-			}
-
-			if g.OnToolResultData != nil && res != "" {
-				var parsed map[string]json.RawMessage
-				if json.Unmarshal([]byte(res), &parsed) == nil {
-					if items, ok := parsed["items"]; ok && len(items) > 0 && items[0] == '[' {
-						g.OnToolResultData(traceID, spanID, tc.Function.Name, items)
-					}
-				}
-			}
-
-			ch <- result{
-				msg: ChatMessage{
-					Role:       "tool",
-					ToolCallID: tc.ID,
-					Content:    res,
-				},
-			}
-		}(i, call)
-	}
-
-	msgs := make([]ChatMessage, 0, len(calls))
-	for i := 0; i < len(calls); i++ {
-		r := <-ch
-		msgs = append(msgs, r.msg)
-	}
-	return msgs
-}
-
-// persistHistory stores the full message sequence to Redis.
-func (g *Gateway) persistHistory(ctx context.Context, conversationID uint64, msgs []ChatMessage) {
-	if g.Redis == nil || conversationID == 0 {
-		return
-	}
-	hist := make([]historyEntry, 0, len(msgs))
-	for _, m := range msgs {
-		if m.Role == "system" {
-			continue
-		}
-		hist = append(hist, chatMsgToEntry(m))
-	}
-	max := g.MaxHistory
-	if max <= 0 {
-		max = 20
-	}
-	// Estimate: each "turn" = user msg + assistant + tool calls + tool results
-	// Keep roughly max*8 entries to accommodate tool messages
-	cap := max * 8
-	if len(hist) > cap {
-		hist = hist[len(hist)-cap:]
-	}
-	if b, e := json.Marshal(hist); e == nil {
-		ttl := g.historyTTL()
-		_ = g.Redis.Set(ctx, g.historyKey(conversationID), b, ttl).Err()
-	}
-}
-
-// ClearHistory removes short-term LLM memory for a conversation.
-func (g *Gateway) ClearHistory(ctx context.Context, conversationID uint64) {
-	if g == nil || g.Redis == nil || conversationID == 0 {
-		return
-	}
-	_ = g.Redis.Del(ctx, g.historyKey(conversationID)).Err()
-}
-
-func (g *Gateway) historyTTL() time.Duration {
-	if g != nil && g.HistoryTTL > 0 {
-		return g.HistoryTTL
-	}
-	return 30 * 24 * time.Hour
-}
-
 func (g *Gateway) systemPrompt() string {
 	if g != nil && strings.TrimSpace(g.SystemPrompt) != "" {
 		return g.SystemPrompt
@@ -423,4 +275,34 @@ func (m ChatMessage) FinishReason() string {
 		return "tool_calls"
 	}
 	return "stop"
+}
+func (g *Gateway) historyKey(conversationID uint64) string {
+	return (&HistoryStore{gw: g}).historyKey(conversationID)
+}
+
+// PersistHistory stores full message history for a conversation.
+func (g *Gateway) PersistHistory(ctx context.Context, conversationID uint64, msgs []ChatMessage) {
+	(&HistoryStore{gw: g}).PersistHistory(ctx, conversationID, msgs)
+}
+
+// BuildMessages loads ALL history (including tool messages) and appends user turn.
+func (g *Gateway) BuildMessages(ctx context.Context, conversationID uint64, userText string) ([]ChatMessage, error) {
+	return (&HistoryStore{gw: g}).BuildMessages(ctx, conversationID, userText)
+}
+
+func (g *Gateway) executeToolCalls(ctx context.Context, calls []ToolCall, traceID string, round int) []ChatMessage {
+	return (&ToolRunner{gw: g}).executeToolCalls(ctx, calls, traceID, round)
+}
+
+func (g *Gateway) persistHistory(ctx context.Context, conversationID uint64, msgs []ChatMessage) {
+	(&HistoryStore{gw: g}).persistHistory(ctx, conversationID, msgs)
+}
+
+// ClearHistory removes short-term LLM memory for a conversation.
+func (g *Gateway) ClearHistory(ctx context.Context, conversationID uint64) {
+	(&HistoryStore{gw: g}).ClearHistory(ctx, conversationID)
+}
+
+func (g *Gateway) historyTTL() time.Duration {
+	return (&HistoryStore{gw: g}).historyTTL()
 }

--- a/internal/aigateway/gateway_history.go
+++ b/internal/aigateway/gateway_history.go
@@ -1,0 +1,91 @@
+package aigateway
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// HistoryStore owns short-term conversation history persistence for the gateway.
+type HistoryStore struct {
+	gw *Gateway
+}
+
+func (h *HistoryStore) historyTTL() time.Duration {
+	if h.gw != nil && h.gw.HistoryTTL > 0 {
+		return h.gw.HistoryTTL
+	}
+	return 30 * 24 * time.Hour
+}
+
+// PersistHistory stores full message history for a conversation (used by
+// callers that assemble history outside the standard turn methods).
+func (h *HistoryStore) PersistHistory(ctx context.Context, conversationID uint64, msgs []ChatMessage) {
+	h.gw.persistHistory(ctx, conversationID, msgs)
+}
+
+// ClearHistory removes short-term LLM memory for a conversation.
+func (h *HistoryStore) ClearHistory(ctx context.Context, conversationID uint64) {
+	if h.gw == nil || h.gw.Redis == nil || conversationID == 0 {
+		return
+	}
+	_ = h.gw.Redis.Del(ctx, h.gw.historyKey(conversationID)).Err()
+}
+
+func (h *HistoryStore) persistHistory(ctx context.Context, conversationID uint64, msgs []ChatMessage) {
+	if h.gw.Redis == nil || conversationID == 0 {
+		return
+	}
+	hist := make([]historyEntry, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role == "system" {
+			continue
+		}
+		hist = append(hist, chatMsgToEntry(m))
+	}
+	max := h.gw.MaxHistory
+	if max <= 0 {
+		max = 20
+	}
+	// Estimate: each "turn" = user msg + assistant + tool calls + tool results
+	// Keep roughly max*8 entries to accommodate tool messages
+	cap := max * 8
+	if len(hist) > cap {
+		hist = hist[len(hist)-cap:]
+	}
+	if b, e := json.Marshal(hist); e == nil {
+		ttl := h.gw.historyTTL()
+		_ = h.gw.Redis.Set(ctx, h.gw.historyKey(conversationID), b, ttl).Err()
+	}
+}
+
+// ClearHistory removes short-term LLM memory for a conversation.
+
+func (h *HistoryStore) historyKey(conversationID uint64) string {
+	p := h.gw.HistoryPrefix
+	if p == "" {
+		p = "mb:agent:hist:"
+	}
+	return fmt.Sprintf("%s%d", p, conversationID)
+}
+
+// BuildMessages loads ALL history (including tool messages) and appends user turn.
+func (h *HistoryStore) BuildMessages(ctx context.Context, conversationID uint64, userText string) ([]ChatMessage, error) {
+	msgs := []ChatMessage{{Role: "system", Content: h.gw.systemPrompt()}}
+	if h.gw.Redis != nil && conversationID > 0 {
+		raw, err := h.gw.Redis.Get(ctx, h.gw.historyKey(conversationID)).Bytes()
+		if err == nil && len(raw) > 0 {
+			var hist []historyEntry
+			if json.Unmarshal(raw, &hist) == nil {
+				for _, h := range hist {
+					if h.Role == "user" || h.Role == "assistant" || h.Role == "tool" {
+						msgs = append(msgs, entryToChatMsg(h))
+					}
+				}
+			}
+		}
+	}
+	msgs = append(msgs, ChatMessage{Role: "user", Content: userText})
+	return msgs, nil
+}

--- a/internal/aigateway/gateway_tools.go
+++ b/internal/aigateway/gateway_tools.go
@@ -1,0 +1,84 @@
+package aigateway
+
+import (
+	"cakecake/internal/logger"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// ToolRunner owns tool-call execution and its progress callbacks.
+type ToolRunner struct {
+	gw *Gateway
+}
+
+func (t *ToolRunner) executeToolCalls(ctx context.Context, calls []ToolCall, traceID string, round int) []ChatMessage {
+	type result struct {
+		msg ChatMessage
+	}
+	ch := make(chan result, len(calls))
+
+	for i, call := range calls {
+		go func(idx int, tc ToolCall) {
+			spanID := fmt.Sprintf("%s-r%d-t%d", traceID, round, idx)
+			parentSpanID := traceID
+
+			if t.gw.OnToolCallStart != nil {
+				var raw json.RawMessage
+				if err := json.Unmarshal([]byte(tc.Function.Arguments), &raw); err != nil && logger.L != nil {
+					logger.L.Warn("aigateway: parse tool call args failed", zap.String("tool", tc.Function.Name), zap.Error(err))
+				}
+				t.gw.OnToolCallStart(traceID, spanID, parentSpanID, tc.Function.Name, raw)
+			}
+
+			start := time.Now()
+			var res string
+			if t.gw.ToolExec != nil {
+				r, err := t.gw.ToolExec.Execute(ctx, tc.Function.Name, json.RawMessage(tc.Function.Arguments))
+				if err != nil {
+					res = fmt.Sprintf(`{"error": "%s"}`, err.Error())
+				} else {
+					res = r
+				}
+			} else {
+				res = `{"error": "tool executor not available"}`
+			}
+			duration := time.Since(start).Milliseconds()
+
+			if t.gw.OnToolCallEnd != nil {
+				summary := res
+				if len(summary) > 80 {
+					summary = summary[:80] + "..."
+				}
+				t.gw.OnToolCallEnd(traceID, spanID, tc.Function.Name, duration, summary)
+			}
+
+			if t.gw.OnToolResultData != nil && res != "" {
+				var parsed map[string]json.RawMessage
+				if json.Unmarshal([]byte(res), &parsed) == nil {
+					if items, ok := parsed["items"]; ok && len(items) > 0 && items[0] == '[' {
+						t.gw.OnToolResultData(traceID, spanID, tc.Function.Name, items)
+					}
+				}
+			}
+
+			ch <- result{
+				msg: ChatMessage{
+					Role:       "tool",
+					ToolCallID: tc.ID,
+					Content:    res,
+				},
+			}
+		}(i, call)
+	}
+
+	msgs := make([]ChatMessage, 0, len(calls))
+	for i := 0; i < len(calls); i++ {
+		r := <-ch
+		msgs = append(msgs, r.msg)
+	}
+	return msgs
+}

--- a/internal/service/agent/agent.go
+++ b/internal/service/agent/agent.go
@@ -86,36 +86,36 @@ type ReplyPusher interface {
 	FormatAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) ([]map[string]interface{}, error)
 }
 
-func (s *AgentService) gatewayReady() bool {
+func (g *AgentGenerationService) gatewayReady() bool {
 	enabled := false
-	if s.RC != nil {
-		enabled = s.RC.GetBool("agent_enabled", s.Cfg != nil && s.Cfg.AgentEnabled)
+	if g.svc.RC != nil {
+		enabled = g.svc.RC.GetBool("agent_enabled", g.svc.Cfg != nil && g.svc.Cfg.AgentEnabled)
 	}
-	if !enabled && s.Cfg != nil {
-		enabled = s.Cfg.AgentEnabled
+	if !enabled && g.svc.Cfg != nil {
+		enabled = g.svc.Cfg.AgentEnabled
 	}
-	return s != nil && enabled && s.Gateway != nil && s.Gateway.LLM != nil &&
-		s.Cfg != nil && strings.TrimSpace(s.Cfg.DeepSeekAPIKey) != ""
+	return g.svc != nil && enabled && g.svc.Gateway != nil && g.svc.Gateway.LLM != nil &&
+		g.svc.Cfg != nil && strings.TrimSpace(g.svc.Cfg.DeepSeekAPIKey) != ""
 }
 
-func (s *AgentService) quotaKey(userID uint64) string {
+func (g *AgentGenerationService) quotaKey(userID uint64) string {
 	day := time.Now().Format("20060102")
 	return fmt.Sprintf("mb:agent:quota:%d:%s", userID, day)
 }
 
 // CheckQuota reports whether the user still has daily agent quota (true when unconfigured).
-func (s *AgentService) CheckQuota(ctx context.Context, userID uint64) bool {
-	if s == nil || s.Redis == nil || s.Cfg == nil {
+func (g *AgentGenerationService) CheckQuota(ctx context.Context, userID uint64) bool {
+	if g.svc == nil || g.svc.Redis == nil || g.svc.Cfg == nil {
 		return true
 	}
-	quota := s.Cfg.AgentDailyQuota
-	if s.RC != nil {
-		quota = s.RC.GetInt("agent_daily_quota", quota)
+	quota := g.svc.Cfg.AgentDailyQuota
+	if g.svc.RC != nil {
+		quota = g.svc.RC.GetInt("agent_daily_quota", quota)
 	}
 	if quota <= 0 {
 		return true
 	}
-	n, err := s.Redis.Get(ctx, s.quotaKey(userID)).Int()
+	n, err := g.svc.Redis.Get(ctx, g.svc.quotaKey(userID)).Int()
 	if err == redis.Nil {
 		return true
 	}
@@ -123,58 +123,58 @@ func (s *AgentService) CheckQuota(ctx context.Context, userID uint64) bool {
 }
 
 // IncrQuota increments the user's daily agent quota counter.
-func (s *AgentService) IncrQuota(ctx context.Context, userID uint64) {
-	if s == nil || s.Redis == nil {
+func (g *AgentGenerationService) IncrQuota(ctx context.Context, userID uint64) {
+	if g.svc == nil || g.svc.Redis == nil {
 		return
 	}
-	key := s.quotaKey(userID)
-	pipe := s.Redis.Pipeline()
+	key := g.svc.quotaKey(userID)
+	pipe := g.svc.Redis.Pipeline()
 	pipe.Incr(ctx, key)
 	pipe.Expire(ctx, key, 48*time.Hour)
 	_, _ = pipe.Exec(ctx)
 }
 
 // EnsureForUser ensures agent conversations exist for a human user.
-func (s *AgentService) EnsureForUser(humanID uint64) error {
-	if s == nil || s.Store == nil || humanID == 0 {
+func (p *AgentProfileService) EnsureForUser(humanID uint64) error {
+	if p.svc == nil || p.svc.Store == nil || humanID == 0 {
 		return nil
 	}
-	return s.Store.EnsureAllAgentConversationsForUser(humanID)
+	return p.svc.Store.EnsureAllAgentConversationsForUser(humanID)
 }
 
 // IsAgentConversation reports whether a conversation belongs to an agent.
-func (s *AgentService) IsAgentConversation(conv *dm.DmConversation) bool {
+func (p *AgentProfileService) IsAgentConversation(conv *dm.DmConversation) bool {
 	return conv != nil && conv.Kind == dm.DmKindAgent
 }
 
 // IsBotUser reports whether a user id belongs to an agent bot.
-func (s *AgentService) IsBotUser(uid uint64) bool {
-	if s == nil || s.Store == nil || uid == 0 {
+func (p *AgentProfileService) IsBotUser(uid uint64) bool {
+	if p.svc == nil || p.svc.Store == nil || uid == 0 {
 		return false
 	}
-	_, err := s.Store.GetAgentProfileByBotUserID(uid)
+	_, err := p.svc.Store.GetAgentProfileByBotUserID(uid)
 	return err == nil
 }
 
-func (s *AgentService) profileForConversation(conv *dm.DmConversation) (*agent.AgentProfile, error) {
-	if s == nil || s.Store == nil || conv == nil {
+func (p *AgentProfileService) profileForConversation(conv *dm.DmConversation) (*agent.AgentProfile, error) {
+	if p.svc == nil || p.svc.Store == nil || conv == nil {
 		return nil, fmt.Errorf("invalid conversation")
 	}
 	if conv.AgentProfileID > 0 {
-		return s.Store.GetAgentProfile(conv.AgentProfileID)
+		return p.svc.Store.GetAgentProfile(conv.AgentProfileID)
 	}
-	if p, err := s.Store.GetAgentProfileByBotUserID(conv.UserLow); err == nil {
+	if p, err := p.svc.Store.GetAgentProfileByBotUserID(conv.UserLow); err == nil {
 		return p, nil
 	}
-	return s.Store.GetAgentProfileByBotUserID(conv.UserHigh)
+	return p.svc.Store.GetAgentProfileByBotUserID(conv.UserHigh)
 }
 
 // PostAssistantMessage persists an assistant reply and updates the conversation.
-func (s *AgentService) PostAssistantMessage(conv *dm.DmConversation, humanID uint64, content string, extra ...string) (*dm.DmMessage, error) {
-	if s == nil || s.Store == nil || conv == nil {
+func (g *AgentGenerationService) PostAssistantMessage(conv *dm.DmConversation, humanID uint64, content string, extra ...string) (*dm.DmMessage, error) {
+	if g.svc == nil || g.svc.Store == nil || conv == nil {
 		return nil, fmt.Errorf("agent service not ready")
 	}
-	profile, err := s.profileForConversation(conv)
+	profile, err := g.svc.profileForConversation(conv)
 	if err != nil {
 		return nil, err
 	}
@@ -216,23 +216,23 @@ func (s *AgentService) PostAssistantMessage(conv *dm.DmConversation, humanID uin
 		r := []rune(preview)
 		preview = string(r[:80]) + "..."
 	}
-	if err := s.Store.PostAssistantMessageTx(&msg, conv, humanID, now, preview); err != nil {
+	if err := g.svc.Store.PostAssistantMessageTx(&msg, conv, humanID, now, preview); err != nil {
 		return nil, err
 	}
-	_ = s.Store.ReloadConversation(conv)
+	_ = g.svc.Store.ReloadConversation(conv)
 	return &msg, nil
 }
 
-func (s *AgentService) applyDynamicGatewayConfig() {
-	if s.Gateway == nil || s.RC == nil {
+func (g *AgentGenerationService) applyDynamicGatewayConfig() {
+	if g.svc.Gateway == nil || g.svc.RC == nil {
 		return
 	}
-	if v := s.RC.GetInt("agent_max_history", s.Gateway.MaxHistory); v > 0 {
-		s.Gateway.MaxHistory = v
+	if v := g.svc.RC.GetInt("agent_max_history", g.svc.Gateway.MaxHistory); v > 0 {
+		g.svc.Gateway.MaxHistory = v
 	}
-	if v := s.RC.Get("agent_history_ttl", ""); v != "" {
+	if v := g.svc.RC.Get("agent_history_ttl", ""); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
-			s.Gateway.HistoryTTL = d
+			g.svc.Gateway.HistoryTTL = d
 		}
 	}
 }
@@ -256,12 +256,12 @@ func humanPeerForConversation(conv *dm.DmConversation, botUserID uint64) uint64 
 }
 
 // GenerateReply produces an AI reply (with tool calls) for a user message.
-func (s *AgentService) GenerateReply(ctx context.Context, conv *dm.DmConversation, userText string) (*GenerateReplyResult, error) {
-	if !s.gatewayReady() {
+func (g *AgentGenerationService) GenerateReply(ctx context.Context, conv *dm.DmConversation, userText string) (*GenerateReplyResult, error) {
+	if !g.svc.gatewayReady() {
 		return nil, fmt.Errorf("ai assistant is not configured")
 	}
-	s.applyDynamicGatewayConfig()
-	profile, err := s.profileForConversation(conv)
+	g.svc.applyDynamicGatewayConfig()
+	profile, err := g.svc.profileForConversation(conv)
 	if err != nil {
 		return nil, fmt.Errorf("ai assistant profile missing")
 	}
@@ -272,41 +272,41 @@ func (s *AgentService) GenerateReply(ctx context.Context, conv *dm.DmConversatio
 	if humanID == 0 {
 		return nil, fmt.Errorf("agent conversation has no human participant")
 	}
-	if s.Sens != nil {
-		if err := s.Sens.Check(userText); err != nil {
+	if g.svc.Sens != nil {
+		if err := g.svc.Sens.Check(userText); err != nil {
 			return nil, fmt.Errorf("message contains sensitive words")
 		}
 	}
 	if strings.TrimSpace(profile.SystemPrompt) == "" {
 		return nil, fmt.Errorf("empty system prompt")
 	}
-	restore := s.agentSystemPrompt(profile)
+	restore := g.svc.agentSystemPrompt(profile)
 	defer restore()
 
-	ctx, cancel := context.WithTimeout(ctx, s.agentReplyTimeout())
+	ctx, cancel := context.WithTimeout(ctx, g.svc.agentReplyTimeout())
 	defer cancel()
 
 	var coll *toolActivityCollector
 	var reply string
-	genID := s.currentGenID(humanID)
-	if s.ToolExec != nil && len(toolkit.DefineTools(s.enabledTools())) > 0 {
+	genID := g.svc.currentGenID(humanID)
+	if g.svc.ToolExec != nil && len(toolkit.DefineTools(g.svc.enabledTools())) > 0 {
 		traceID := generateTraceID()
-		s.setupToolCallbacks(traceID, humanID)
-		defer s.clearToolCallbacks()
-		coll = installToolCollectors(s.Gateway)
-		tools := toolkit.DefineTools(s.enabledTools())
-		s.Gateway.ToolExec = s.ToolExec
-		reply, err = s.Gateway.CompleteUserTurnWithToolsStream(ctx, conv.ID, userText, tools, traceID, s.deltaSender(humanID, genID))
+		g.svc.setupToolCallbacks(traceID, humanID)
+		defer g.svc.clearToolCallbacks()
+		coll = installToolCollectors(g.svc.Gateway)
+		tools := toolkit.DefineTools(g.svc.enabledTools())
+		g.svc.Gateway.ToolExec = g.svc.ToolExec
+		reply, err = g.svc.Gateway.CompleteUserTurnWithToolsStream(ctx, conv.ID, userText, tools, traceID, g.svc.deltaSender(humanID, genID))
 	} else {
-		s.setupToolCallbacks("", humanID)
-		defer s.clearToolCallbacks()
-		reply, err = s.Gateway.CompleteUserTurnStream(ctx, conv.ID, userText, s.deltaSender(humanID, genID))
+		g.svc.setupToolCallbacks("", humanID)
+		defer g.svc.clearToolCallbacks()
+		reply, err = g.svc.Gateway.CompleteUserTurnStream(ctx, conv.ID, userText, g.svc.deltaSender(humanID, genID))
 	}
 	if err != nil {
 		return nil, err
 	}
-	if s.Sens != nil {
-		if err := s.Sens.Check(reply); err != nil {
+	if g.svc.Sens != nil {
+		if err := g.svc.Sens.Check(reply); err != nil {
 			return &GenerateReplyResult{Content: "抱歉，AI 助手暂时无法回复，请稍后再试。"}, nil
 		}
 	}
@@ -320,21 +320,21 @@ func (s *AgentService) GenerateReply(ctx context.Context, conv *dm.DmConversatio
 // GenerateSuggestions asks the model for follow-up question chips based on a
 // finished reply. Callers run it after the reply is persisted so the message
 // can be shown immediately instead of waiting for a second LLM round trip.
-func (s *AgentService) GenerateSuggestions(ctx context.Context, reply string) []string {
-	return s.generateSuggestions(ctx, reply)
+func (g *AgentGenerationService) GenerateSuggestions(ctx context.Context, reply string) []string {
+	return g.svc.generateSuggestions(ctx, reply)
 }
 
 // UpdateMessageSuggestions persists follow-up chips on an assistant message.
-func (s *AgentService) UpdateMessageSuggestions(ctx context.Context, messageID uint64, suggestions []string) error {
-	if s == nil || s.Store == nil {
+func (g *AgentGenerationService) UpdateMessageSuggestions(ctx context.Context, messageID uint64, suggestions []string) error {
+	if g.svc == nil || g.svc.Store == nil {
 		return fmt.Errorf("agent service not ready")
 	}
-	return s.Store.UpdateMessageSuggestions(ctx, messageID, suggestions)
+	return g.svc.Store.UpdateMessageSuggestions(ctx, messageID, suggestions)
 }
 
 // returns nil on any error or unparseable output.
-func (s *AgentService) generateSuggestions(ctx context.Context, reply string) []string {
-	if s.Gateway == nil || s.Gateway.LLM == nil || strings.TrimSpace(reply) == "" {
+func (g *AgentGenerationService) generateSuggestions(ctx context.Context, reply string) []string {
+	if g.svc.Gateway == nil || g.svc.Gateway.LLM == nil || strings.TrimSpace(reply) == "" {
 		return nil
 	}
 	r := []rune(reply)
@@ -347,7 +347,7 @@ func (s *AgentService) generateSuggestions(ctx context.Context, reply string) []
 	}
 	ctx2, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	out, err := s.Gateway.LLM.Complete(ctx2, msgs)
+	out, err := g.svc.Gateway.LLM.Complete(ctx2, msgs)
 	if err != nil || strings.TrimSpace(out) == "" {
 		return nil
 	}
@@ -379,13 +379,13 @@ func parseSuggestionsJSON(raw string) []string {
 }
 
 // agentReplyTimeout resolves the effective LLM request timeout (runtime config first).
-func (s *AgentService) agentReplyTimeout() time.Duration {
+func (g *AgentGenerationService) agentReplyTimeout() time.Duration {
 	timeout := 90 * time.Second
-	if s.Cfg != nil && s.Cfg.AgentRequestTimeout > 0 {
-		timeout = s.Cfg.AgentRequestTimeout
+	if g.svc.Cfg != nil && g.svc.Cfg.AgentRequestTimeout > 0 {
+		timeout = g.svc.Cfg.AgentRequestTimeout
 	}
-	if s.RC != nil {
-		if v := s.RC.Get("agent_request_timeout", ""); v != "" {
+	if g.svc.RC != nil {
+		if v := g.svc.RC.Get("agent_request_timeout", ""); v != "" {
 			if d, err := time.ParseDuration(v); err == nil && d > 0 {
 				timeout = d
 			}
@@ -395,19 +395,19 @@ func (s *AgentService) agentReplyTimeout() time.Duration {
 }
 
 // agentSystemPrompt swaps in the effective system prompt, returning a restore func.
-func (s *AgentService) agentSystemPrompt(profile *agent.AgentProfile) func() {
-	globalPrompt := s.Store.GetGlobalSystemPrompt()
-	prev := s.Gateway.SystemPrompt
-	s.Gateway.SystemPrompt = globalPrompt + "\n\n" + strings.TrimSpace(profile.SystemPrompt)
-	return func() { s.Gateway.SystemPrompt = prev }
+func (g *AgentGenerationService) agentSystemPrompt(profile *agent.AgentProfile) func() {
+	globalPrompt := g.svc.Store.GetGlobalSystemPrompt()
+	prev := g.svc.Gateway.SystemPrompt
+	g.svc.Gateway.SystemPrompt = globalPrompt + "\n\n" + strings.TrimSpace(profile.SystemPrompt)
+	return func() { g.svc.Gateway.SystemPrompt = prev }
 }
 
 // ResetConversation clears an agent conversation and posts a fresh opening message.
-func (s *AgentService) ResetConversation(ctx context.Context, conv *dm.DmConversation, humanID uint64) (*dm.DmMessage, error) {
-	if s == nil || s.Store == nil || conv == nil || humanID == 0 {
+func (g *AgentGenerationService) ResetConversation(ctx context.Context, conv *dm.DmConversation, humanID uint64) (*dm.DmMessage, error) {
+	if g.svc == nil || g.svc.Store == nil || conv == nil || humanID == 0 {
 		return nil, fmt.Errorf("agent service not ready")
 	}
-	profile, err := s.profileForConversation(conv)
+	profile, err := g.svc.profileForConversation(conv)
 	if err != nil {
 		return nil, err
 	}
@@ -425,12 +425,12 @@ func (s *AgentService) ResetConversation(ctx context.Context, conv *dm.DmConvers
 		Content:        welcome,
 		CreatedAt:      now,
 	}
-	if err := s.Store.ResetConversationTx(conv, &msg, humanID, now, preview); err != nil {
+	if err := g.svc.Store.ResetConversationTx(conv, &msg, humanID, now, preview); err != nil {
 		return nil, err
 	}
-	if s.Gateway != nil {
-		s.Gateway.ClearHistory(ctx, conv.ID)
+	if g.svc.Gateway != nil {
+		g.svc.Gateway.ClearHistory(ctx, conv.ID)
 	}
-	_ = s.Store.ReloadConversation(conv)
+	_ = g.svc.Store.ReloadConversation(conv)
 	return &msg, nil
 }

--- a/internal/service/agent/agent_facade.go
+++ b/internal/service/agent/agent_facade.go
@@ -1,0 +1,382 @@
+package agent
+
+import (
+	"cakecake/internal/model/agent"
+	"cakecake/internal/model/dm"
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// AgentService facade: domain methods are delegated to the profile, generation
+// and feedback services. Client contracts, handlers and tests keep depending
+// on AgentService; the facade splits into per-domain proto services at migration.
+// All state stays on AgentService (single source of truth) for now.
+
+// MaxProfiles delegates to the corresponding domain service.
+func (s *AgentService) MaxProfiles() int {
+	return (&AgentProfileService{svc: s}).MaxProfiles()
+}
+
+// UnmarshalWelcomeList delegates to the corresponding domain service.
+func (s *AgentService) UnmarshalWelcomeList(raw json.RawMessage, fallback []string) ([]string, error) {
+	return (&AgentProfileService{svc: s}).UnmarshalWelcomeList(raw, fallback)
+}
+
+// NormalizeSlug delegates to the corresponding domain service.
+func (s *AgentService) NormalizeSlug(slug string) (string, error) {
+	return (&AgentProfileService{svc: s}).NormalizeSlug(slug)
+}
+
+// ReloadProfiles delegates to the corresponding domain service.
+func (s *AgentService) ReloadProfiles() {
+	(&AgentProfileService{svc: s}).ReloadProfiles()
+}
+
+// ListAgentProfiles delegates to the corresponding domain service.
+func (s *AgentService) ListAgentProfiles(ctx context.Context) ([]agent.AgentProfile, error) {
+	return (&AgentProfileService{svc: s}).ListAgentProfiles(ctx)
+}
+
+// GetAgentProfile delegates to the corresponding domain service.
+func (s *AgentService) GetAgentProfile(ctx context.Context, id uint64) (*agent.AgentProfile, error) {
+	return (&AgentProfileService{svc: s}).GetAgentProfile(ctx, id)
+}
+
+// CreateAgentProfile delegates to the corresponding domain service.
+func (s *AgentService) CreateAgentProfile(ctx context.Context, p *agent.AgentProfile) error {
+	return (&AgentProfileService{svc: s}).CreateAgentProfile(ctx, p)
+}
+
+// UpdateAgentProfile delegates to the corresponding domain service.
+func (s *AgentService) UpdateAgentProfile(ctx context.Context, id uint64, updates map[string]interface{}) error {
+	return (&AgentProfileService{svc: s}).UpdateAgentProfile(ctx, id, updates)
+}
+
+// DeleteAgentProfile delegates to the corresponding domain service.
+func (s *AgentService) DeleteAgentProfile(ctx context.Context, id uint64) error {
+	return (&AgentProfileService{svc: s}).DeleteAgentProfile(ctx, id)
+}
+
+// CountActiveAgentProfiles delegates to the corresponding domain service.
+func (s *AgentService) CountActiveAgentProfiles(ctx context.Context) (int64, error) {
+	return (&AgentProfileService{svc: s}).CountActiveAgentProfiles(ctx)
+}
+
+// CheckAgentSlugExists delegates to the corresponding domain service.
+func (s *AgentService) CheckAgentSlugExists(ctx context.Context, slug string) (bool, error) {
+	return (&AgentProfileService{svc: s}).CheckAgentSlugExists(ctx, slug)
+}
+
+// UpdateAgentAvatar delegates to the corresponding domain service.
+func (s *AgentService) UpdateAgentAvatar(ctx context.Context, id uint64, avatarURL string) error {
+	return (&AgentProfileService{svc: s}).UpdateAgentAvatar(ctx, id, avatarURL)
+}
+
+// GetGlobalSystemPrompt delegates to the corresponding domain service.
+func (s *AgentService) GetGlobalSystemPrompt(ctx context.Context) string {
+	return (&AgentProfileService{svc: s}).GetGlobalSystemPrompt(ctx)
+}
+
+// ProfileCount delegates to the corresponding domain service.
+func (s *AgentService) ProfileCount(ctx context.Context) (int64, error) {
+	return (&AgentProfileService{svc: s}).ProfileCount(ctx)
+}
+
+// CreateAgentBotUser delegates to the corresponding domain service.
+func (s *AgentService) CreateAgentBotUser(ctx context.Context, slug, displayName, sign, avatarURL string) (uint64, error) {
+	return (&AgentProfileService{svc: s}).CreateAgentBotUser(ctx, slug, displayName, sign, avatarURL)
+}
+
+// RenameAgentProfileSlug delegates to the corresponding domain service.
+func (s *AgentService) RenameAgentProfileSlug(ctx context.Context, p *agent.AgentProfile, newSlug string) error {
+	return (&AgentProfileService{svc: s}).RenameAgentProfileSlug(ctx, p, newSlug)
+}
+
+// SyncAgentProfile delegates to the corresponding domain service.
+func (s *AgentService) SyncAgentProfile(ctx context.Context, p *agent.AgentProfile) error {
+	return (&AgentProfileService{svc: s}).SyncAgentProfile(ctx, p)
+}
+
+// EnsureAgentProfiles delegates to the corresponding domain service.
+func (s *AgentService) EnsureAgentProfiles(ctx context.Context) error {
+	return (&AgentProfileService{svc: s}).EnsureAgentProfiles(ctx)
+}
+
+// SetMessageFeedback delegates to the corresponding domain service.
+func (s *AgentService) SetMessageFeedback(ctx context.Context, messageID uint64, userID uint64, feedback string) error {
+	return (&AgentFeedbackService{svc: s}).SetMessageFeedback(ctx, messageID, userID, feedback)
+}
+
+// ListAgentFeedbacks delegates to the corresponding domain service.
+func (s *AgentService) ListAgentFeedbacks(ctx context.Context, limit int, offset int) ([]agent.AgentFeedback, error) {
+	return (&AgentFeedbackService{svc: s}).ListAgentFeedbacks(ctx, limit, offset)
+}
+
+// ListAgentFeedbacksWithContent delegates to the corresponding domain service.
+func (s *AgentService) ListAgentFeedbacksWithContent(ctx context.Context, limit int, offset int) ([]AgentFeedbackRow, error) {
+	return (&AgentFeedbackService{svc: s}).ListAgentFeedbacksWithContent(ctx, limit, offset)
+}
+
+// RunReply delegates to the corresponding domain service.
+func (s *AgentService) RunReply(humanID uint64, conv *dm.DmConversation, userText string) {
+	(&AgentGenerationService{svc: s}).RunReply(humanID, conv, userText)
+}
+
+// ResumeReply delegates to the corresponding domain service.
+func (s *AgentService) ResumeReply(uid uint64, convID uint64) {
+	(&AgentGenerationService{svc: s}).ResumeReply(uid, convID)
+}
+
+func (s *AgentService) resumeReplyLocal(uid uint64, convID uint64) {
+	(&AgentGenerationService{svc: s}).resumeReplyLocal(uid, convID)
+}
+
+func (s *AgentService) handleControl(uid uint64, ctrl map[string]interface{}) {
+	(&AgentGenerationService{svc: s}).handleControl(uid, ctrl)
+}
+
+// RegenerateReply delegates to the corresponding domain service.
+func (s *AgentService) RegenerateReply(uid uint64, convID uint64) {
+	(&AgentGenerationService{svc: s}).RegenerateReply(uid, convID)
+}
+
+func (s *AgentService) regenerateWelcome(uid uint64, conv *dm.DmConversation, current string) {
+	(&AgentGenerationService{svc: s}).regenerateWelcome(uid, conv, current)
+}
+
+func (s *AgentService) continueReply(uid uint64, convID uint64, partial string) {
+	(&AgentGenerationService{svc: s}).continueReply(uid, convID, partial)
+}
+
+func (s *AgentService) continueFromDraft(ctx context.Context, conv *dm.DmConversation, partial string, genID uint64) (string, error) {
+	return (&AgentGenerationService{svc: s}).continueFromDraft(ctx, conv, partial, genID)
+}
+
+func (s *AgentService) streamTail(humanID uint64, genID uint64, tail string) {
+	(&AgentGenerationService{svc: s}).streamTail(humanID, genID, tail)
+}
+
+func (s *AgentService) persistAndPushReply(humanID uint64, conv *dm.DmConversation, result *GenerateReplyResult) *dm.DmMessage {
+	return (&AgentGenerationService{svc: s}).persistAndPushReply(humanID, conv, result)
+}
+
+func (s *AgentService) pushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) {
+	(&AgentGenerationService{svc: s}).pushAgentMessage(ctx, humanID, conv, msg)
+}
+
+func (s *AgentService) attachSuggestions(humanID uint64, messageID uint64, reply string) {
+	(&AgentGenerationService{svc: s}).attachSuggestions(humanID, messageID, reply)
+}
+
+func (s *AgentService) pushFallback(ctx context.Context, humanID uint64, conv *dm.DmConversation, text string) {
+	(&AgentGenerationService{svc: s}).pushFallback(ctx, humanID, conv, text)
+}
+
+func (s *AgentService) pushContinueMode(uid uint64, mode string) {
+	(&AgentGenerationService{svc: s}).pushContinueMode(uid, mode)
+}
+
+func (s *AgentService) latestUserTurnHasAssistantReply(uid uint64, convID uint64) bool {
+	return (&AgentGenerationService{svc: s}).latestUserTurnHasAssistantReply(uid, convID)
+}
+
+func (s *AgentService) runLock(uid uint64) *sync.Mutex {
+	return (&AgentGenerationService{svc: s}).runLock(uid)
+}
+
+func (s *AgentService) deltaSender(humanID uint64, genID uint64) func(string) {
+	return (&AgentGenerationService{svc: s}).deltaSender(humanID, genID)
+}
+
+func (s *AgentService) publishEvent(ctx context.Context, uid uint64, payload interface{}) {
+	(&AgentGenerationService{svc: s}).publishEvent(ctx, uid, payload)
+}
+
+func (s *AgentService) publishControl(ctx context.Context, uid uint64, payload interface{}) {
+	(&AgentGenerationService{svc: s}).publishControl(ctx, uid, payload)
+}
+
+func (s *AgentService) draftText(uid uint64) string {
+	return (&AgentGenerationService{svc: s}).draftText(uid)
+}
+
+func (s *AgentService) currentGenID(uid uint64) uint64 {
+	return (&AgentGenerationService{svc: s}).currentGenID(uid)
+}
+
+func (s *AgentService) generationState(uid uint64) *agentGenState {
+	return (&AgentGenerationService{svc: s}).generationState(uid)
+}
+
+func (s *AgentService) beginGeneration(uid uint64, cancel context.CancelFunc) uint64 {
+	return (&AgentGenerationService{svc: s}).beginGeneration(uid, cancel)
+}
+
+func (s *AgentService) endGeneration(uid uint64, genID uint64) {
+	(&AgentGenerationService{svc: s}).endGeneration(uid, genID)
+}
+
+func (s *AgentService) saveDraft(uid uint64, st *agentGenState) {
+	(&AgentGenerationService{svc: s}).saveDraft(uid, st)
+}
+
+func (s *AgentService) clearDraft(uid uint64) {
+	(&AgentGenerationService{svc: s}).clearDraft(uid)
+}
+
+func (s *AgentService) supersedeGeneration(uid uint64) {
+	(&AgentGenerationService{svc: s}).supersedeGeneration(uid)
+}
+
+func (s *AgentService) dropCurrentGeneration(uid uint64) {
+	(&AgentGenerationService{svc: s}).dropCurrentGeneration(uid)
+}
+
+func (s *AgentService) hasRunningGeneration(uid uint64) bool {
+	return (&AgentGenerationService{svc: s}).hasRunningGeneration(uid)
+}
+
+func (s *AgentService) storePendingReply(uid uint64, genID uint64, conv *dm.DmConversation, result *GenerateReplyResult) {
+	(&AgentGenerationService{svc: s}).storePendingReply(uid, genID, conv, result)
+}
+
+func (s *AgentService) takePendingReply(uid uint64) (*dm.DmConversation, *GenerateReplyResult, uint64, bool) {
+	return (&AgentGenerationService{svc: s}).takePendingReply(uid)
+}
+
+// PauseGeneration delegates to the corresponding domain service.
+func (s *AgentService) PauseGeneration(uid uint64) {
+	(&AgentGenerationService{svc: s}).PauseGeneration(uid)
+}
+
+func (s *AgentService) pauseGeneration(uid uint64) {
+	(&AgentGenerationService{svc: s}).pauseGeneration(uid)
+}
+
+func (s *AgentService) resumeGeneration(uid uint64) {
+	(&AgentGenerationService{svc: s}).resumeGeneration(uid)
+}
+
+func (s *AgentService) isGenerationPaused(uid uint64) bool {
+	return (&AgentGenerationService{svc: s}).isGenerationPaused(uid)
+}
+
+func (s *AgentService) clearGenerationState(uid uint64) {
+	(&AgentGenerationService{svc: s}).clearGenerationState(uid)
+}
+
+func (s *AgentService) writeSnapshot(uid uint64, snap *genSnapshot) {
+	(&AgentGenerationService{svc: s}).writeSnapshot(uid, snap)
+}
+
+func (s *AgentService) readSnapshot(uid uint64) *genSnapshot {
+	return (&AgentGenerationService{svc: s}).readSnapshot(uid)
+}
+
+func (s *AgentService) clearSnapshot(uid uint64, genID uint64) {
+	(&AgentGenerationService{svc: s}).clearSnapshot(uid, genID)
+}
+
+func (s *AgentService) updateSnapshotPaused(uid uint64, genID uint64, paused bool, pauseSeq uint64) {
+	(&AgentGenerationService{svc: s}).updateSnapshotPaused(uid, genID, paused, pauseSeq)
+}
+
+func (s *AgentService) snapshotRunning(uid uint64, genID uint64, convID uint64) {
+	(&AgentGenerationService{svc: s}).snapshotRunning(uid, genID, convID)
+}
+
+func (s *AgentService) snapshotPending(uid uint64, genID uint64, convID uint64, result *GenerateReplyResult) {
+	(&AgentGenerationService{svc: s}).snapshotPending(uid, genID, convID, result)
+}
+
+func (s *AgentService) gatewayReady() bool {
+	return (&AgentGenerationService{svc: s}).gatewayReady()
+}
+
+func (s *AgentService) quotaKey(userID uint64) string {
+	return (&AgentGenerationService{svc: s}).quotaKey(userID)
+}
+
+// CheckQuota delegates to the corresponding domain service.
+func (s *AgentService) CheckQuota(ctx context.Context, userID uint64) bool {
+	return (&AgentGenerationService{svc: s}).CheckQuota(ctx, userID)
+}
+
+// IncrQuota delegates to the corresponding domain service.
+func (s *AgentService) IncrQuota(ctx context.Context, userID uint64) {
+	(&AgentGenerationService{svc: s}).IncrQuota(ctx, userID)
+}
+
+// EnsureForUser delegates to the corresponding domain service.
+func (s *AgentService) EnsureForUser(humanID uint64) error {
+	return (&AgentProfileService{svc: s}).EnsureForUser(humanID)
+}
+
+// IsAgentConversation delegates to the corresponding domain service.
+func (s *AgentService) IsAgentConversation(conv *dm.DmConversation) bool {
+	return (&AgentProfileService{svc: s}).IsAgentConversation(conv)
+}
+
+// IsBotUser delegates to the corresponding domain service.
+func (s *AgentService) IsBotUser(uid uint64) bool {
+	return (&AgentProfileService{svc: s}).IsBotUser(uid)
+}
+
+func (s *AgentService) profileForConversation(conv *dm.DmConversation) (*agent.AgentProfile, error) {
+	return (&AgentProfileService{svc: s}).profileForConversation(conv)
+}
+
+// PostAssistantMessage delegates to the corresponding domain service.
+func (s *AgentService) PostAssistantMessage(conv *dm.DmConversation, humanID uint64, content string, extra ...string) (*dm.DmMessage, error) {
+	return (&AgentGenerationService{svc: s}).PostAssistantMessage(conv, humanID, content, extra...)
+}
+
+func (s *AgentService) applyDynamicGatewayConfig() {
+	(&AgentGenerationService{svc: s}).applyDynamicGatewayConfig()
+}
+
+// GenerateReply delegates to the corresponding domain service.
+func (s *AgentService) GenerateReply(ctx context.Context, conv *dm.DmConversation, userText string) (*GenerateReplyResult, error) {
+	return (&AgentGenerationService{svc: s}).GenerateReply(ctx, conv, userText)
+}
+
+// GenerateSuggestions delegates to the corresponding domain service.
+func (s *AgentService) GenerateSuggestions(ctx context.Context, reply string) []string {
+	return (&AgentGenerationService{svc: s}).GenerateSuggestions(ctx, reply)
+}
+
+// UpdateMessageSuggestions delegates to the corresponding domain service.
+func (s *AgentService) UpdateMessageSuggestions(ctx context.Context, messageID uint64, suggestions []string) error {
+	return (&AgentGenerationService{svc: s}).UpdateMessageSuggestions(ctx, messageID, suggestions)
+}
+
+func (s *AgentService) generateSuggestions(ctx context.Context, reply string) []string {
+	return (&AgentGenerationService{svc: s}).generateSuggestions(ctx, reply)
+}
+
+func (s *AgentService) agentReplyTimeout() time.Duration {
+	return (&AgentGenerationService{svc: s}).agentReplyTimeout()
+}
+
+func (s *AgentService) agentSystemPrompt(profile *agent.AgentProfile) func() {
+	return (&AgentGenerationService{svc: s}).agentSystemPrompt(profile)
+}
+
+// ResetConversation delegates to the corresponding domain service.
+func (s *AgentService) ResetConversation(ctx context.Context, conv *dm.DmConversation, humanID uint64) (*dm.DmMessage, error) {
+	return (&AgentGenerationService{svc: s}).ResetConversation(ctx, conv, humanID)
+}
+
+func (s *AgentService) enabledTools() map[string]bool {
+	return (&AgentGenerationService{svc: s}).enabledTools()
+}
+
+func (s *AgentService) setupToolCallbacks(traceID string, humanID uint64) {
+	(&AgentGenerationService{svc: s}).setupToolCallbacks(traceID, humanID)
+}
+
+func (s *AgentService) clearToolCallbacks() {
+	(&AgentGenerationService{svc: s}).clearToolCallbacks()
+}

--- a/internal/service/agent/agent_feedback.go
+++ b/internal/service/agent/agent_feedback.go
@@ -7,30 +7,35 @@ import (
 	"context"
 )
 
+// AgentFeedbackService owns the agent feedback domain.
+type AgentFeedbackService struct {
+	svc *AgentService
+}
+
 // SetMessageFeedback records or toggles a user's like/dislike on a message.
-func (s *AgentService) SetMessageFeedback(ctx context.Context, messageID uint64, userID uint64, feedback string) error {
-	if s == nil || s.Store == nil {
+func (f *AgentFeedbackService) SetMessageFeedback(ctx context.Context, messageID uint64, userID uint64, feedback string) error {
+	if f.svc == nil || f.svc.Store == nil {
 		return fmt.Errorf("agent service not ready")
 	}
 	if feedback != "like" && feedback != "dislike" {
 		return fmt.Errorf("invalid feedback value")
 	}
-	return s.Store.SetMessageFeedback(ctx, messageID, userID, feedback)
+	return f.svc.Store.SetMessageFeedback(ctx, messageID, userID, feedback)
 }
 
 // ListAgentFeedbacks returns feedback rows for the admin console.
-func (s *AgentService) ListAgentFeedbacks(ctx context.Context, limit int, offset int) ([]agent.AgentFeedback, error) {
-	if s == nil || s.Store == nil {
+func (f *AgentFeedbackService) ListAgentFeedbacks(ctx context.Context, limit int, offset int) ([]agent.AgentFeedback, error) {
+	if f.svc == nil || f.svc.Store == nil {
 		return nil, fmt.Errorf("agent service not ready")
 	}
-	return s.Store.ListAgentFeedbacks(ctx, limit, offset)
+	return f.svc.Store.ListAgentFeedbacks(ctx, limit, offset)
 }
 
 // ListAgentFeedbacksWithContent returns feedback rows joined with the rated
 // assistant message content for the admin console.
-func (s *AgentService) ListAgentFeedbacksWithContent(ctx context.Context, limit int, offset int) ([]AgentFeedbackRow, error) {
-	if s == nil || s.Store == nil {
+func (f *AgentFeedbackService) ListAgentFeedbacksWithContent(ctx context.Context, limit int, offset int) ([]AgentFeedbackRow, error) {
+	if f.svc == nil || f.svc.Store == nil {
 		return nil, fmt.Errorf("agent service not ready")
 	}
-	return s.Store.ListAgentFeedbacksWithContent(ctx, limit, offset)
+	return f.svc.Store.ListAgentFeedbacksWithContent(ctx, limit, offset)
 }

--- a/internal/service/agent/agent_orchestrate.go
+++ b/internal/service/agent/agent_orchestrate.go
@@ -17,51 +17,56 @@ import (
 	"go.uber.org/zap"
 )
 
+// AgentGenerationService owns reply orchestration, generation state and snapshots.
+type AgentGenerationService struct {
+	svc *AgentService
+}
+
 // RunReply generates and delivers an assistant message asynchronously. It owns
 // the whole generation lifecycle: supersede, quota, persistence, push and
 // follow-up suggestions. The handler only forwards the HTTP trigger.
-func (s *AgentService) RunReply(humanID uint64, conv *dm.DmConversation, userText string) {
-	if s == nil || conv == nil {
+func (g *AgentGenerationService) RunReply(humanID uint64, conv *dm.DmConversation, userText string) {
+	if g.svc == nil || conv == nil {
 		return
 	}
 	// Any new generation supersedes an in-flight/paused one: cancel it and
 	// drop its state so its deltas are discarded and any paused-completed
 	// reply waiting to be persisted is abandoned.
-	s.publishControl(context.Background(), humanID, map[string]interface{}{"type": "supersede", "from": s.InstanceID})
-	s.supersedeGeneration(humanID)
+	g.svc.publishControl(context.Background(), humanID, map[string]interface{}{"type": "supersede", "from": g.svc.InstanceID})
+	g.svc.supersedeGeneration(humanID)
 	// Register the generation synchronously so a WS agent_cancel arriving
 	// right after the send can never miss the in-flight generation.
 	ctx, cancel := context.WithCancel(context.Background())
-	genID := s.beginGeneration(humanID, cancel)
+	genID := g.svc.beginGeneration(humanID, cancel)
 	if genID == 0 {
 		cancel()
 		return
 	}
-	s.snapshotRunning(humanID, genID, conv.ID)
-	runMu := s.runLock(humanID)
+	g.svc.snapshotRunning(humanID, genID, conv.ID)
+	runMu := g.svc.runLock(humanID)
 	go func() {
 		defer cancel()
 		runMu.Lock()
 		defer runMu.Unlock()
-		if !s.CheckQuota(ctx, humanID) {
-			s.endGeneration(humanID, genID)
-			s.pushFallback(ctx, humanID, conv, "今日 AI 对话次数已达上限，请明天再试。")
+		if !g.svc.CheckQuota(ctx, humanID) {
+			g.svc.endGeneration(humanID, genID)
+			g.svc.pushFallback(ctx, humanID, conv, "今日 AI 对话次数已达上限，请明天再试。")
 			return
 		}
-		result, err := s.GenerateReply(ctx, conv, userText)
+		result, err := g.svc.GenerateReply(ctx, conv, userText)
 		if err != nil {
 			// Capture the stop decision before endGeneration releases the
 			// cancel func: after that, ctx.Err() is always non-nil even for a
 			// regular failure.
 			stopped := errors.Is(err, context.Canceled) || ctx.Err() != nil
-			s.endGeneration(humanID, genID)
+			g.svc.endGeneration(humanID, genID)
 			if stopped {
 				// User stopped generation; the frontend already cleared the
 				// streamed draft. Do not push a confusing fallback message.
 				return
 			}
-			if s.Log != nil {
-				s.Log.Warn("agent generate", zap.Uint64("conv", conv.ID), zap.Error(err))
+			if g.svc.Log != nil {
+				g.svc.Log.Warn("agent generate", zap.Uint64("conv", conv.ID), zap.Error(err))
 			}
 			msg := "AI 助手暂时不可用，请稍后再试。"
 			if strings.Contains(err.Error(), "sensitive") {
@@ -73,19 +78,19 @@ func (s *AgentService) RunReply(humanID uint64, conv *dm.DmConversation, userTex
 			if strings.Contains(err.Error(), "disabled") {
 				msg = "AI 助手已暂停服务，请稍后再试。"
 			}
-			s.pushFallback(ctx, humanID, conv, msg)
+			g.svc.pushFallback(ctx, humanID, conv, msg)
 			return
 		}
-		if s.isGenerationPaused(humanID) {
+		if g.svc.isGenerationPaused(humanID) {
 			// Completed while paused: keep the state so a resume can flush the
 			// buffer, then persist this reply exactly once.
-			s.storePendingReply(humanID, genID, conv, result)
+			g.svc.storePendingReply(humanID, genID, conv, result)
 			return
 		}
-		s.endGeneration(humanID, genID)
-		msg := s.persistAndPushReply(humanID, conv, result)
+		g.svc.endGeneration(humanID, genID)
+		msg := g.svc.persistAndPushReply(humanID, conv, result)
 		if msg != nil && result != nil {
-			go s.attachSuggestions(humanID, msg.ID, result.Content)
+			go g.svc.attachSuggestions(humanID, msg.ID, result.Content)
 		}
 	}()
 }
@@ -94,111 +99,111 @@ func (s *AgentService) RunReply(humanID uint64, conv *dm.DmConversation, userTex
 // verbatim; if it completed while paused, the full reply is persisted now.
 // Only when the generation fully ended with no reply does it fall back to a
 // re-prompt continuation from the server-side draft (never from frontend text).
-func (s *AgentService) ResumeReply(uid uint64, convID uint64) {
-	if s == nil || uid == 0 {
+func (g *AgentGenerationService) ResumeReply(uid uint64, convID uint64) {
+	if g.svc == nil || uid == 0 {
 		return
 	}
 	// If the generation is owned by another replica, forward the control
 	// command; the owner applies the exact same resume logic locally.
-	if snap := s.readSnapshot(uid); snap != nil && snap.Owner != "" && snap.Owner != s.InstanceID {
-		s.publishControl(context.Background(), uid, map[string]interface{}{
-			"type": "resume", "conv_id": convID, "from": s.InstanceID,
+	if snap := g.svc.readSnapshot(uid); snap != nil && snap.Owner != "" && snap.Owner != g.svc.InstanceID {
+		g.svc.publishControl(context.Background(), uid, map[string]interface{}{
+			"type": "resume", "conv_id": convID, "from": g.svc.InstanceID,
 		})
 		return
 	}
-	s.resumeReplyLocal(uid, convID)
+	g.svc.resumeReplyLocal(uid, convID)
 }
 
 // resumeReplyLocal is the single-instance resume implementation (owner path).
-func (s *AgentService) resumeReplyLocal(uid uint64, convID uint64) {
-	if s == nil || uid == 0 {
+func (g *AgentGenerationService) resumeReplyLocal(uid uint64, convID uint64) {
+	if g.svc == nil || uid == 0 {
 		return
 	}
-	s.resumeGeneration(uid)
+	g.svc.resumeGeneration(uid)
 	// Fast path: the generation is still running, so continue only needs to
 	// un-pause and flush the buffered deltas.
-	if s.hasRunningGeneration(uid) {
-		s.pushContinueMode(uid, "buffer")
+	if g.svc.hasRunningGeneration(uid) {
+		g.svc.pushContinueMode(uid, "buffer")
 		return
 	}
 	// Serialize the completed-generation path per user: a double continue (or a
 	// continue racing a fresh send) must never re-prompt after the reply row
 	// already exists, otherwise the DB ends up with two assistant messages.
-	runMu := s.runLock(uid)
+	runMu := g.svc.runLock(uid)
 	runMu.Lock()
 	defer runMu.Unlock()
-	if s.hasRunningGeneration(uid) {
-		s.pushContinueMode(uid, "buffer")
+	if g.svc.hasRunningGeneration(uid) {
+		g.svc.pushContinueMode(uid, "buffer")
 		return
 	}
-	conv, result, genID, ok := s.takePendingReply(uid)
+	conv, result, genID, ok := g.svc.takePendingReply(uid)
 	if ok {
-		s.pushContinueMode(uid, "buffer")
-		s.endGeneration(uid, genID)
-		msg := s.persistAndPushReply(uid, conv, result)
+		g.svc.pushContinueMode(uid, "buffer")
+		g.svc.endGeneration(uid, genID)
+		msg := g.svc.persistAndPushReply(uid, conv, result)
 		if msg != nil && result != nil {
-			go s.attachSuggestions(uid, msg.ID, result.Content)
+			go g.svc.attachSuggestions(uid, msg.ID, result.Content)
 		}
 		return
 	}
 	// The reply may have already completed (the stop arrived too late). Only
 	// re-prompt when the latest user turn has no persisted assistant reply yet.
-	draft := s.draftText(uid)
-	if strings.TrimSpace(draft) == "" || s.latestUserTurnHasAssistantReply(uid, convID) {
+	draft := g.svc.draftText(uid)
+	if strings.TrimSpace(draft) == "" || g.svc.latestUserTurnHasAssistantReply(uid, convID) {
 		return
 	}
-	s.pushContinueMode(uid, "reprompt")
-	s.continueReply(uid, convID, draft)
+	g.svc.pushContinueMode(uid, "reprompt")
+	g.svc.continueReply(uid, convID, draft)
 }
 
 // handleControl applies a cross-instance control command. Only the replica
 // that owns the user's running generation acts; everyone else ignores it.
-func (s *AgentService) handleControl(uid uint64, ctrl map[string]interface{}) {
-	if s == nil || uid == 0 {
+func (g *AgentGenerationService) handleControl(uid uint64, ctrl map[string]interface{}) {
+	if g.svc == nil || uid == 0 {
 		return
 	}
 	// Ignore controls this instance published itself: the initiating path
 	// already applied them locally (e.g. RunReply superseded before starting
 	// the new generation; applying the echoed supersede would cancel it).
-	if from, _ := ctrl["from"].(string); from != "" && from == s.InstanceID {
+	if from, _ := ctrl["from"].(string); from != "" && from == g.svc.InstanceID {
 		return
 	}
 	switch ctrl["type"] {
 	case "pause":
-		if s.hasRunningGeneration(uid) {
-			s.pauseGeneration(uid)
+		if g.svc.hasRunningGeneration(uid) {
+			g.svc.pauseGeneration(uid)
 		}
 	case "resume":
-		snap := s.readSnapshot(uid)
-		if snap == nil || snap.Owner != s.InstanceID {
+		snap := g.svc.readSnapshot(uid)
+		if snap == nil || snap.Owner != g.svc.InstanceID {
 			return
 		}
 		convID := uint64(0)
 		if v, ok := ctrl["conv_id"].(float64); ok {
 			convID = uint64(v)
 		}
-		s.resumeReplyLocal(uid, convID)
+		g.svc.resumeReplyLocal(uid, convID)
 	case "supersede":
-		s.supersedeGeneration(uid)
+		g.svc.supersedeGeneration(uid)
 	}
 }
 
 // RegenerateReply re-runs the assistant reply for the last user message in the
 // conversation (posts a fresh assistant version).
-func (s *AgentService) RegenerateReply(uid uint64, convID uint64) {
-	if s == nil || s.Dm == nil || convID == 0 {
+func (g *AgentGenerationService) RegenerateReply(uid uint64, convID uint64) {
+	if g.svc == nil || g.svc.Dm == nil || convID == 0 {
 		return
 	}
 	ctx := context.Background()
-	conv, err := s.Dm.GetConversationByID(ctx, convID)
+	conv, err := g.svc.Dm.GetConversationByID(ctx, convID)
 	if err != nil || conv == nil {
 		return
 	}
-	part, err := s.Dm.GetParticipant(ctx, convID, uid)
+	part, err := g.svc.Dm.GetParticipant(ctx, convID, uid)
 	if err != nil || part == nil {
 		return
 	}
-	msgs, err := s.Dm.ListMessages(ctx, convID, 0, 20)
+	msgs, err := g.svc.Dm.ListMessages(ctx, convID, 0, 20)
 	if err != nil {
 		return
 	}
@@ -215,23 +220,23 @@ func (s *AgentService) RegenerateReply(uid uint64, convID uint64) {
 				break
 			}
 		}
-		s.regenerateWelcome(uid, conv, current)
+		g.svc.regenerateWelcome(uid, conv, current)
 		return
 	}
 	// Regenerate supersedes any in-flight generation (RunReply re-checks).
-	s.publishControl(context.Background(), uid, map[string]interface{}{"type": "supersede", "from": s.InstanceID})
-	s.supersedeGeneration(uid)
-	s.RunReply(uid, conv, lastUser)
+	g.svc.publishControl(context.Background(), uid, map[string]interface{}{"type": "supersede", "from": g.svc.InstanceID})
+	g.svc.supersedeGeneration(uid)
+	g.svc.RunReply(uid, conv, lastUser)
 }
 
 // regenerateWelcome posts a new opening welcome from the profile's welcome
 // pool, preferring an entry different from the current one so the regenerated
 // version is not an exact duplicate.
-func (s *AgentService) regenerateWelcome(uid uint64, conv *dm.DmConversation, current string) {
-	if s == nil || conv == nil {
+func (g *AgentGenerationService) regenerateWelcome(uid uint64, conv *dm.DmConversation, current string) {
+	if g.svc == nil || conv == nil {
 		return
 	}
-	profile, err := s.profileForConversation(conv)
+	profile, err := g.svc.profileForConversation(conv)
 	if err != nil || profile == nil {
 		return
 	}
@@ -240,14 +245,14 @@ func (s *AgentService) regenerateWelcome(uid uint64, conv *dm.DmConversation, cu
 	if strings.TrimSpace(welcome) == "" {
 		return
 	}
-	msg, err := s.PostAssistantMessage(conv, uid, welcome)
+	msg, err := g.svc.PostAssistantMessage(conv, uid, welcome)
 	if err != nil {
-		if s.Log != nil {
-			s.Log.Error("agent persist regenerated welcome", zap.Error(err))
+		if g.svc.Log != nil {
+			g.svc.Log.Error("agent persist regenerated welcome", zap.Error(err))
 		}
 		return
 	}
-	s.pushAgentMessage(context.Background(), uid, conv, msg)
+	g.svc.pushAgentMessage(context.Background(), uid, conv, msg)
 }
 
 // pickDifferentWelcome picks a random pool entry different from current,
@@ -289,50 +294,50 @@ func lastUserText(msgs []dm.DmMessage) string {
 }
 
 // continueReply re-prompts the model from the server-side draft text.
-func (s *AgentService) continueReply(uid uint64, convID uint64, partial string) {
-	if s == nil || s.Dm == nil || convID == 0 || strings.TrimSpace(partial) == "" {
+func (g *AgentGenerationService) continueReply(uid uint64, convID uint64, partial string) {
+	if g.svc == nil || g.svc.Dm == nil || convID == 0 || strings.TrimSpace(partial) == "" {
 		return
 	}
-	s.publishControl(context.Background(), uid, map[string]interface{}{"type": "supersede", "from": s.InstanceID})
-	s.supersedeGeneration(uid)
+	g.svc.publishControl(context.Background(), uid, map[string]interface{}{"type": "supersede", "from": g.svc.InstanceID})
+	g.svc.supersedeGeneration(uid)
 	ctx, cancel := context.WithCancel(context.Background())
-	genID := s.beginGeneration(uid, cancel)
+	genID := g.svc.beginGeneration(uid, cancel)
 	if genID == 0 {
 		cancel()
 		return
 	}
-	s.snapshotRunning(uid, genID, convID)
-	runMu := s.runLock(uid)
+	g.svc.snapshotRunning(uid, genID, convID)
+	runMu := g.svc.runLock(uid)
 	go func() {
 		defer cancel()
-		defer s.endGeneration(uid, genID)
+		defer g.svc.endGeneration(uid, genID)
 		runMu.Lock()
 		defer runMu.Unlock()
-		conv, err := s.Dm.GetConversationByID(ctx, convID)
+		conv, err := g.svc.Dm.GetConversationByID(ctx, convID)
 		if err != nil || conv == nil {
 			return
 		}
-		if _, err := s.Dm.GetParticipant(ctx, convID, uid); err != nil {
+		if _, err := g.svc.Dm.GetParticipant(ctx, convID, uid); err != nil {
 			return
 		}
-		full, err := s.continueFromDraft(ctx, conv, partial, genID)
+		full, err := g.svc.continueFromDraft(ctx, conv, partial, genID)
 		if err != nil {
-			if s.Log != nil {
-				s.Log.Warn("agent continue", zap.Uint64("conv", conv.ID), zap.Error(err))
+			if g.svc.Log != nil {
+				g.svc.Log.Warn("agent continue", zap.Uint64("conv", conv.ID), zap.Error(err))
 			}
 			// Keep the user's stopped draft intact: no fallback message, so the
 			// frontend can retry or copy the partial.
 			return
 		}
-		msg, err := s.PostAssistantMessage(conv, uid, full)
+		msg, err := g.svc.PostAssistantMessage(conv, uid, full)
 		if err != nil {
-			if s.Log != nil {
-				s.Log.Error("agent persist continuation", zap.Error(err))
+			if g.svc.Log != nil {
+				g.svc.Log.Error("agent persist continuation", zap.Error(err))
 			}
 			return
 		}
-		s.pushAgentMessage(ctx, uid, conv, msg)
-		go s.attachSuggestions(uid, msg.ID, full)
+		g.svc.pushAgentMessage(ctx, uid, conv, msg)
+		go g.svc.attachSuggestions(uid, msg.ID, full)
 	}()
 }
 
@@ -341,11 +346,11 @@ func (s *AgentService) continueReply(uid uint64, convID uint64, partial string) 
 // structurally stitched with the draft before anything reaches the client;
 // the clean tail is then paced out as deltas. This removes the fuzzy
 // text-overlap guessing that used to split code blocks at the seam.
-func (s *AgentService) continueFromDraft(ctx context.Context, conv *dm.DmConversation, partial string, genID uint64) (string, error) {
-	if s == nil || s.Gateway == nil || s.Gateway.LLM == nil {
+func (g *AgentGenerationService) continueFromDraft(ctx context.Context, conv *dm.DmConversation, partial string, genID uint64) (string, error) {
+	if g.svc == nil || g.svc.Gateway == nil || g.svc.Gateway.LLM == nil {
 		return "", fmt.Errorf("ai assistant is not configured")
 	}
-	profile, err := s.profileForConversation(conv)
+	profile, err := g.svc.profileForConversation(conv)
 	if err != nil {
 		return "", fmt.Errorf("ai assistant profile missing")
 	}
@@ -356,17 +361,17 @@ func (s *AgentService) continueFromDraft(ctx context.Context, conv *dm.DmConvers
 	if humanID == 0 {
 		return "", fmt.Errorf("agent conversation has no human participant")
 	}
-	restore := s.agentSystemPrompt(profile)
+	restore := g.svc.agentSystemPrompt(profile)
 	defer restore()
 
-	ctx2, cancel := context.WithTimeout(ctx, s.agentReplyTimeout())
+	ctx2, cancel := context.WithTimeout(ctx, g.svc.agentReplyTimeout())
 	defer cancel()
 
 	instruction := "请从中断处直接继续你的回答，不要重复已经写过的内容，也不要另起一段重新讲解。"
 	if partialEndsInsideCodeFence(partial) {
 		instruction = "你现在正处于未闭合的代码块内部：请先接着写完这段代码（不要重复已写行，不要跳出代码块写新段落），用三个反引号闭合代码块后，如有必要再用一两句话继续讲解。"
 	}
-	msgs, err := s.Gateway.BuildMessages(ctx2, conv.ID, "")
+	msgs, err := g.svc.Gateway.BuildMessages(ctx2, conv.ID, "")
 	if err != nil {
 		return "", err
 	}
@@ -384,7 +389,7 @@ func (s *AgentService) continueFromDraft(ctx context.Context, conv *dm.DmConvers
 		aigateway.ChatMessage{Role: "assistant", Content: partial},
 		aigateway.ChatMessage{Role: "user", Content: instruction},
 	)
-	replyText, err := s.Gateway.LLM.Complete(ctx2, msgs)
+	replyText, err := g.svc.Gateway.LLM.Complete(ctx2, msgs)
 	if err != nil {
 		return "", err
 	}
@@ -397,16 +402,16 @@ func (s *AgentService) continueFromDraft(ctx context.Context, conv *dm.DmConvers
 	// partial/instruction messages from the stored history.
 	hist := append([]aigateway.ChatMessage{}, msgs[:len(msgs)-2]...)
 	hist = append(hist, aigateway.ChatMessage{Role: "assistant", Content: full})
-	s.Gateway.PersistHistory(ctx2, conv.ID, hist)
+	g.svc.Gateway.PersistHistory(ctx2, conv.ID, hist)
 
-	s.streamTail(humanID, genID, tail)
+	g.svc.streamTail(humanID, genID, tail)
 	return full, nil
 }
 
 // streamTail paces the stitched continuation out as deltas so the fallback
 // still has a typewriter feel; the client never sees the unstitched seam.
-func (s *AgentService) streamTail(humanID uint64, genID uint64, tail string) {
-	if (s.ChatHub == nil && s.Relay == nil) || tail == "" {
+func (g *AgentGenerationService) streamTail(humanID uint64, genID uint64, tail string) {
+	if (g.svc.ChatHub == nil && g.svc.Relay == nil) || tail == "" {
 		return
 	}
 	runes := []rune(tail)
@@ -416,72 +421,72 @@ func (s *AgentService) streamTail(humanID uint64, genID uint64, tail string) {
 		if end > len(runes) {
 			end = len(runes)
 		}
-		s.deltaSender(humanID, genID)(string(runes[i:end]))
+		g.svc.deltaSender(humanID, genID)(string(runes[i:end]))
 		time.Sleep(12 * time.Millisecond)
 	}
 }
 
 // persistAndPushReply writes the finished reply to the DB and pushes it.
-func (s *AgentService) persistAndPushReply(humanID uint64, conv *dm.DmConversation, result *GenerateReplyResult) *dm.DmMessage {
-	if s == nil || conv == nil || result == nil {
+func (g *AgentGenerationService) persistAndPushReply(humanID uint64, conv *dm.DmConversation, result *GenerateReplyResult) *dm.DmMessage {
+	if g.svc == nil || conv == nil || result == nil {
 		return nil
 	}
 	ctx := context.Background()
-	s.IncrQuota(ctx, humanID)
+	g.svc.IncrQuota(ctx, humanID)
 	sugJSON := ""
 	if len(result.Suggestions) > 0 {
 		if b, e := json.Marshal(result.Suggestions); e == nil {
 			sugJSON = string(b)
 		}
 	}
-	msg, err := s.PostAssistantMessage(conv, humanID, result.Content, string(result.ToolActivities), string(result.ToolResultData), sugJSON)
+	msg, err := g.svc.PostAssistantMessage(conv, humanID, result.Content, string(result.ToolActivities), string(result.ToolResultData), sugJSON)
 	if err != nil {
-		if s.Log != nil {
-			s.Log.Error("agent persist reply", zap.Error(err))
+		if g.svc.Log != nil {
+			g.svc.Log.Error("agent persist reply", zap.Error(err))
 		}
 		return nil
 	}
-	s.pushAgentMessage(ctx, humanID, conv, msg)
+	g.svc.pushAgentMessage(ctx, humanID, conv, msg)
 	return msg
 }
 
 // pushAgentMessage formats a persisted agent message through the Pusher
 // adapter and delivers every returned payload (locally or cross-instance).
-func (s *AgentService) pushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) {
-	if s == nil || s.Pusher == nil || humanID == 0 || conv == nil || msg == nil {
+func (g *AgentGenerationService) pushAgentMessage(ctx context.Context, humanID uint64, conv *dm.DmConversation, msg *dm.DmMessage) {
+	if g.svc == nil || g.svc.Pusher == nil || humanID == 0 || conv == nil || msg == nil {
 		return
 	}
-	payloads, err := s.Pusher.FormatAgentMessage(ctx, humanID, conv, msg)
+	payloads, err := g.svc.Pusher.FormatAgentMessage(ctx, humanID, conv, msg)
 	if err != nil {
-		if s.Log != nil {
-			s.Log.Error("agent format message", zap.Error(err))
+		if g.svc.Log != nil {
+			g.svc.Log.Error("agent format message", zap.Error(err))
 		}
 		return
 	}
 	for _, payload := range payloads {
-		s.publishEvent(ctx, humanID, payload)
+		g.svc.publishEvent(ctx, humanID, payload)
 	}
 }
 
 // attachSuggestions generates follow-up chips after the reply is already
 // persisted and pushed, so the UI never waits for the second LLM round trip.
-func (s *AgentService) attachSuggestions(humanID uint64, messageID uint64, reply string) {
-	if s == nil || messageID == 0 || strings.TrimSpace(reply) == "" {
+func (g *AgentGenerationService) attachSuggestions(humanID uint64, messageID uint64, reply string) {
+	if g.svc == nil || messageID == 0 || strings.TrimSpace(reply) == "" {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	sugg := s.GenerateSuggestions(ctx, reply)
+	sugg := g.svc.GenerateSuggestions(ctx, reply)
 	if len(sugg) == 0 {
 		return
 	}
-	if err := s.UpdateMessageSuggestions(ctx, messageID, sugg); err != nil {
-		if s.Log != nil {
-			s.Log.Warn("agent attach suggestions", zap.Uint64("message_id", messageID), zap.Error(err))
+	if err := g.svc.UpdateMessageSuggestions(ctx, messageID, sugg); err != nil {
+		if g.svc.Log != nil {
+			g.svc.Log.Warn("agent attach suggestions", zap.Uint64("message_id", messageID), zap.Error(err))
 		}
 		return
 	}
-	s.publishEvent(ctx, humanID, map[string]interface{}{
+	g.svc.publishEvent(ctx, humanID, map[string]interface{}{
 		"type":        "agent_suggestions",
 		"message_id":  messageID,
 		"suggestions": sugg,
@@ -489,24 +494,24 @@ func (s *AgentService) attachSuggestions(humanID uint64, messageID uint64, reply
 }
 
 // pushFallback persists and pushes an assistant fallback message.
-func (s *AgentService) pushFallback(ctx context.Context, humanID uint64, conv *dm.DmConversation, text string) {
-	msg, err := s.PostAssistantMessage(conv, humanID, text)
+func (g *AgentGenerationService) pushFallback(ctx context.Context, humanID uint64, conv *dm.DmConversation, text string) {
+	msg, err := g.svc.PostAssistantMessage(conv, humanID, text)
 	if err != nil {
-		if s.Log != nil {
-			s.Log.Error("agent fallback message", zap.Error(err))
+		if g.svc.Log != nil {
+			g.svc.Log.Error("agent fallback message", zap.Error(err))
 		}
 		return
 	}
-	s.pushAgentMessage(ctx, humanID, conv, msg)
+	g.svc.pushAgentMessage(ctx, humanID, conv, msg)
 }
 
 // pushContinueMode tells the frontend whether a continue is a seamless buffer
 // replay or a re-prompt fallback.
-func (s *AgentService) pushContinueMode(uid uint64, mode string) {
-	if s == nil || uid == 0 {
+func (g *AgentGenerationService) pushContinueMode(uid uint64, mode string) {
+	if g.svc == nil || uid == 0 {
 		return
 	}
-	s.publishEvent(context.Background(), uid, map[string]interface{}{
+	g.svc.publishEvent(context.Background(), uid, map[string]interface{}{
 		"type": "agent_continue_mode",
 		"mode": mode,
 	})
@@ -514,12 +519,12 @@ func (s *AgentService) pushContinueMode(uid uint64, mode string) {
 
 // latestUserTurnHasAssistantReply reports whether the latest user message in
 // the conversation already has a persisted assistant reply.
-func (s *AgentService) latestUserTurnHasAssistantReply(uid uint64, convID uint64) bool {
-	if s == nil || s.Dm == nil || convID == 0 {
+func (g *AgentGenerationService) latestUserTurnHasAssistantReply(uid uint64, convID uint64) bool {
+	if g.svc == nil || g.svc.Dm == nil || convID == 0 {
 		return false
 	}
 	// ListMessages returns newest-first (id DESC).
-	msgs, err := s.Dm.ListMessages(context.Background(), convID, 0, 20)
+	msgs, err := g.svc.Dm.ListMessages(context.Background(), convID, 0, 20)
 	if err != nil {
 		return false
 	}
@@ -536,16 +541,16 @@ func (s *AgentService) latestUserTurnHasAssistantReply(uid uint64, convID uint64
 
 // runLock returns the per-user serialization lock: at most one agent
 // generation goroutine runs per user at any moment.
-func (s *AgentService) runLock(uid uint64) *sync.Mutex {
-	s.runLocksMu.Lock()
-	defer s.runLocksMu.Unlock()
-	if s.runLocks == nil {
-		s.runLocks = make(map[uint64]*sync.Mutex)
+func (g *AgentGenerationService) runLock(uid uint64) *sync.Mutex {
+	g.svc.runLocksMu.Lock()
+	defer g.svc.runLocksMu.Unlock()
+	if g.svc.runLocks == nil {
+		g.svc.runLocks = make(map[uint64]*sync.Mutex)
 	}
-	mu := s.runLocks[uid]
+	mu := g.svc.runLocks[uid]
 	if mu == nil {
 		mu = &sync.Mutex{}
-		s.runLocks[uid] = mu
+		g.svc.runLocks[uid] = mu
 	}
 	return mu
 }

--- a/internal/service/agent/agent_profiles.go
+++ b/internal/service/agent/agent_profiles.go
@@ -8,92 +8,97 @@ import (
 	"context"
 )
 
+// AgentProfileService owns the agent-profile domain (CRUD, bot user, slug, prompt).
+type AgentProfileService struct {
+	svc *AgentService
+}
+
 // MaxProfiles returns the maximum number of agent profiles allowed.
-func (s *AgentService) MaxProfiles() int {
+func (ps *AgentProfileService) MaxProfiles() int {
 	return data.MaxAgentProfilesLimit()
 }
 
 // UnmarshalWelcomeList parses welcome messages from JSON, falling back when needed.
-func (s *AgentService) UnmarshalWelcomeList(raw json.RawMessage, fallback []string) ([]string, error) {
+func (ps *AgentProfileService) UnmarshalWelcomeList(raw json.RawMessage, fallback []string) ([]string, error) {
 	return data.UnmarshalWelcomeList(raw, fallback)
 }
 
 // NormalizeSlug normalizes an agent profile slug.
-func (s *AgentService) NormalizeSlug(slug string) (string, error) {
+func (ps *AgentProfileService) NormalizeSlug(slug string) (string, error) {
 	return data.NormalizeAgentSlug(slug)
 }
 
 // ReloadProfiles reloads agent profiles (no-op; profiles are ensured lazily).
-func (s *AgentService) ReloadProfiles() {}
+func (ps *AgentProfileService) ReloadProfiles() {}
 
 // ListAgentProfiles returns all agent profiles.
-func (s *AgentService) ListAgentProfiles(ctx context.Context) ([]agent.AgentProfile, error) {
-	return s.Store.ListAgentProfiles(ctx)
+func (ps *AgentProfileService) ListAgentProfiles(ctx context.Context) ([]agent.AgentProfile, error) {
+	return ps.svc.Store.ListAgentProfiles(ctx)
 }
 
 // GetAgentProfile returns an agent profile by ID.
-func (s *AgentService) GetAgentProfile(ctx context.Context, id uint64) (*agent.AgentProfile, error) {
-	return s.Store.GetAgentProfile(id)
+func (ps *AgentProfileService) GetAgentProfile(ctx context.Context, id uint64) (*agent.AgentProfile, error) {
+	return ps.svc.Store.GetAgentProfile(id)
 }
 
 // CreateAgentProfile creates a new agent profile.
-func (s *AgentService) CreateAgentProfile(ctx context.Context, p *agent.AgentProfile) error {
-	return s.Store.CreateAgentProfile(ctx, p)
+func (ps *AgentProfileService) CreateAgentProfile(ctx context.Context, p *agent.AgentProfile) error {
+	return ps.svc.Store.CreateAgentProfile(ctx, p)
 }
 
 // UpdateAgentProfile updates an agent profile.
-func (s *AgentService) UpdateAgentProfile(ctx context.Context, id uint64, updates map[string]interface{}) error {
-	return s.Store.UpdateAgentProfile(ctx, id, updates)
+func (ps *AgentProfileService) UpdateAgentProfile(ctx context.Context, id uint64, updates map[string]interface{}) error {
+	return ps.svc.Store.UpdateAgentProfile(ctx, id, updates)
 }
 
 // DeleteAgentProfile deletes an agent profile by ID.
-func (s *AgentService) DeleteAgentProfile(ctx context.Context, id uint64) error {
-	return s.Store.DeleteAgentProfile(ctx, id)
+func (ps *AgentProfileService) DeleteAgentProfile(ctx context.Context, id uint64) error {
+	return ps.svc.Store.DeleteAgentProfile(ctx, id)
 }
 
 // CountActiveAgentProfiles returns the count of enabled agent profiles.
-func (s *AgentService) CountActiveAgentProfiles(ctx context.Context) (int64, error) {
-	return s.Store.CountActiveAgentProfiles(ctx)
+func (ps *AgentProfileService) CountActiveAgentProfiles(ctx context.Context) (int64, error) {
+	return ps.svc.Store.CountActiveAgentProfiles(ctx)
 }
 
 // CheckAgentSlugExists checks if a slug is already taken.
-func (s *AgentService) CheckAgentSlugExists(ctx context.Context, slug string) (bool, error) {
-	return s.Store.CheckAgentSlugExists(ctx, slug)
+func (ps *AgentProfileService) CheckAgentSlugExists(ctx context.Context, slug string) (bool, error) {
+	return ps.svc.Store.CheckAgentSlugExists(ctx, slug)
 }
 
 // UpdateAgentAvatar updates the avatar_url of an agent profile.
-func (s *AgentService) UpdateAgentAvatar(ctx context.Context, id uint64, avatarURL string) error {
-	return s.Store.UpdateAgentAvatar(ctx, id, avatarURL)
+func (ps *AgentProfileService) UpdateAgentAvatar(ctx context.Context, id uint64, avatarURL string) error {
+	return ps.svc.Store.UpdateAgentAvatar(ctx, id, avatarURL)
 }
 
 // GetGlobalSystemPrompt returns the global system prompt from agent settings.
-func (s *AgentService) GetGlobalSystemPrompt(ctx context.Context) string {
-	return s.Store.GetGlobalSystemPrompt()
+func (ps *AgentProfileService) GetGlobalSystemPrompt(ctx context.Context) string {
+	return ps.svc.Store.GetGlobalSystemPrompt()
 }
 
 // ProfileCount returns total number of agent profiles.
-func (s *AgentService) ProfileCount(ctx context.Context) (int64, error) {
-	return s.Store.ProfileCount(ctx)
+func (ps *AgentProfileService) ProfileCount(ctx context.Context) (int64, error) {
+	return ps.svc.Store.ProfileCount(ctx)
 }
 
 // CreateAgentBotUser creates a non-login system user for a new profile.
-func (s *AgentService) CreateAgentBotUser(ctx context.Context, slug, displayName, sign, avatarURL string) (uint64, error) {
-	return s.Store.CreateAgentBotUser(ctx, slug, displayName, sign, avatarURL)
+func (ps *AgentProfileService) CreateAgentBotUser(ctx context.Context, slug, displayName, sign, avatarURL string) (uint64, error) {
+	return ps.svc.Store.CreateAgentBotUser(ctx, slug, displayName, sign, avatarURL)
 }
 
 // RenameAgentProfileSlug updates a profile slug and the linked bot user username.
-func (s *AgentService) RenameAgentProfileSlug(ctx context.Context, p *agent.AgentProfile, newSlug string) error {
-	return s.Store.RenameAgentProfileSlug(ctx, p, newSlug)
+func (ps *AgentProfileService) RenameAgentProfileSlug(ctx context.Context, p *agent.AgentProfile, newSlug string) error {
+	return ps.svc.Store.RenameAgentProfileSlug(ctx, p, newSlug)
 }
 
 // SyncAgentProfile copies profile display fields onto the bot user row.
-func (s *AgentService) SyncAgentProfile(ctx context.Context, p *agent.AgentProfile) error {
-	return s.Store.SyncAgentProfile(ctx, p)
+func (ps *AgentProfileService) SyncAgentProfile(ctx context.Context, p *agent.AgentProfile) error {
+	return ps.svc.Store.SyncAgentProfile(ctx, p)
 }
 
 // EnsureAgentProfiles migrates legacy settings and guarantees at least one profile.
-func (s *AgentService) EnsureAgentProfiles(ctx context.Context) error {
-	return s.Store.EnsureAgentProfiles(s.Cfg, s.Log)
+func (ps *AgentProfileService) EnsureAgentProfiles(ctx context.Context) error {
+	return ps.svc.Store.EnsureAgentProfiles(ps.svc.Cfg, ps.svc.Log)
 }
 
 // AgentBotUsername returns the internal username for a profile slug.

--- a/internal/service/agent/agent_snapshot.go
+++ b/internal/service/agent/agent_snapshot.go
@@ -33,22 +33,22 @@ type pendingSnap struct {
 	Suggestions    string `json:"suggestions,omitempty"`
 }
 
-func (s *AgentService) writeSnapshot(uid uint64, snap *genSnapshot) {
-	if s == nil || s.Redis == nil || uid == 0 || snap == nil {
+func (g *AgentGenerationService) writeSnapshot(uid uint64, snap *genSnapshot) {
+	if g.svc == nil || g.svc.Redis == nil || uid == 0 || snap == nil {
 		return
 	}
 	b, err := json.Marshal(snap)
 	if err != nil {
 		return
 	}
-	_ = s.Redis.Set(context.Background(), data.AgentGenSnapshotKey(uid), b, agentSnapshotTTL).Err()
+	_ = g.svc.Redis.Set(context.Background(), data.AgentGenSnapshotKey(uid), b, agentSnapshotTTL).Err()
 }
 
-func (s *AgentService) readSnapshot(uid uint64) *genSnapshot {
-	if s == nil || s.Redis == nil || uid == 0 {
+func (g *AgentGenerationService) readSnapshot(uid uint64) *genSnapshot {
+	if g.svc == nil || g.svc.Redis == nil || uid == 0 {
 		return nil
 	}
-	raw, err := s.Redis.Get(context.Background(), data.AgentGenSnapshotKey(uid)).Bytes()
+	raw, err := g.svc.Redis.Get(context.Background(), data.AgentGenSnapshotKey(uid)).Bytes()
 	if err != nil {
 		return nil
 	}
@@ -61,40 +61,40 @@ func (s *AgentService) readSnapshot(uid uint64) *genSnapshot {
 
 // clearSnapshot removes the snapshot only when it still belongs to genID (a
 // finished generation can never clear a newer generation's snapshot).
-func (s *AgentService) clearSnapshot(uid uint64, genID uint64) {
-	if s == nil || s.Redis == nil || uid == 0 || genID == 0 {
+func (g *AgentGenerationService) clearSnapshot(uid uint64, genID uint64) {
+	if g.svc == nil || g.svc.Redis == nil || uid == 0 || genID == 0 {
 		return
 	}
-	snap := s.readSnapshot(uid)
+	snap := g.svc.readSnapshot(uid)
 	if snap == nil || snap.GenID != genID {
 		return
 	}
-	_ = s.Redis.Del(context.Background(), data.AgentGenSnapshotKey(uid)).Err()
+	_ = g.svc.Redis.Del(context.Background(), data.AgentGenSnapshotKey(uid)).Err()
 }
 
 // updateSnapshotPaused mirrors a local pause/resume change into the snapshot
 // (guarded by generation id).
-func (s *AgentService) updateSnapshotPaused(uid uint64, genID uint64, paused bool, pauseSeq uint64) {
-	if s == nil || s.Redis == nil || uid == 0 || genID == 0 {
+func (g *AgentGenerationService) updateSnapshotPaused(uid uint64, genID uint64, paused bool, pauseSeq uint64) {
+	if g.svc == nil || g.svc.Redis == nil || uid == 0 || genID == 0 {
 		return
 	}
-	snap := s.readSnapshot(uid)
+	snap := g.svc.readSnapshot(uid)
 	if snap == nil || snap.GenID != genID {
 		return
 	}
 	snap.Paused = paused
 	snap.PauseSeq = pauseSeq
-	s.writeSnapshot(uid, snap)
+	g.svc.writeSnapshot(uid, snap)
 }
 
 // snapshotRunning marks the snapshot as a running generation owned by this
 // instance (called right after beginGeneration on the owner).
-func (s *AgentService) snapshotRunning(uid uint64, genID uint64, convID uint64) {
-	if s == nil || s.Redis == nil || uid == 0 || genID == 0 {
+func (g *AgentGenerationService) snapshotRunning(uid uint64, genID uint64, convID uint64) {
+	if g.svc == nil || g.svc.Redis == nil || uid == 0 || genID == 0 {
 		return
 	}
-	s.writeSnapshot(uid, &genSnapshot{
-		Owner:   s.InstanceID,
+	g.svc.writeSnapshot(uid, &genSnapshot{
+		Owner:   g.svc.InstanceID,
 		GenID:   genID,
 		Running: true,
 		ConvID:  convID,
@@ -103,11 +103,11 @@ func (s *AgentService) snapshotRunning(uid uint64, genID uint64, convID uint64) 
 
 // snapshotPending marks the snapshot as finished-while-paused with the reply
 // serialized, so a remote replica can recover it.
-func (s *AgentService) snapshotPending(uid uint64, genID uint64, convID uint64, result *GenerateReplyResult) {
-	if s == nil || s.Redis == nil || uid == 0 || genID == 0 || result == nil {
+func (g *AgentGenerationService) snapshotPending(uid uint64, genID uint64, convID uint64, result *GenerateReplyResult) {
+	if g.svc == nil || g.svc.Redis == nil || uid == 0 || genID == 0 || result == nil {
 		return
 	}
-	snap := s.readSnapshot(uid)
+	snap := g.svc.readSnapshot(uid)
 	if snap == nil || snap.GenID != genID {
 		return
 	}
@@ -124,5 +124,5 @@ func (s *AgentService) snapshotPending(uid uint64, genID uint64, convID uint64, 
 			snap.Pending.Suggestions = string(b)
 		}
 	}
-	s.writeSnapshot(uid, snap)
+	g.svc.writeSnapshot(uid, snap)
 }

--- a/internal/service/agent/agent_state.go
+++ b/internal/service/agent/agent_state.go
@@ -44,12 +44,12 @@ type pendingAgentReply struct {
 // the human user's ChatHub connection and honors pause/drop generation state.
 // Each LLM call gets its own closure (capturing its own genID), so concurrent
 // users and superseded generations never cross-wire or leak late deltas.
-func (s *AgentService) deltaSender(humanID uint64, genID uint64) func(string) {
+func (g *AgentGenerationService) deltaSender(humanID uint64, genID uint64) func(string) {
 	return func(delta string) {
 		if delta == "" {
 			return
 		}
-		if st := s.generationState(humanID); st != nil {
+		if st := g.svc.generationState(humanID); st != nil {
 			st.mu.Lock()
 			if st.dropped || st.genID != genID {
 				st.mu.Unlock()
@@ -65,8 +65,8 @@ func (s *AgentService) deltaSender(humanID uint64, genID uint64) func(string) {
 			}
 			st.mu.Unlock()
 		}
-		if s.ChatHub != nil || s.Relay != nil {
-			s.publishEvent(context.Background(), humanID, map[string]interface{}{
+		if g.svc.ChatHub != nil || g.svc.Relay != nil {
+			g.svc.publishEvent(context.Background(), humanID, map[string]interface{}{
 				"type": "agent_delta",
 				"body": map[string]interface{}{
 					"content": delta,
@@ -79,51 +79,51 @@ func (s *AgentService) deltaSender(humanID uint64, genID uint64) func(string) {
 // publishEvent delivers an agent event to the user's WebSocket connection.
 // With a relay wired it is published to Redis and every replica fans it out to
 // its local ChatHub; without one it is pushed directly (single-process mode).
-func (s *AgentService) publishEvent(ctx context.Context, uid uint64, payload interface{}) {
-	if s == nil || uid == 0 {
+func (g *AgentGenerationService) publishEvent(ctx context.Context, uid uint64, payload interface{}) {
+	if g.svc == nil || uid == 0 {
 		return
 	}
-	if s.Relay != nil {
-		_ = s.Relay.PublishEvent(ctx, uid, payload)
-	} else if s.ChatHub != nil {
-		s.ChatHub.PushJSON(uid, payload)
+	if g.svc.Relay != nil {
+		_ = g.svc.Relay.PublishEvent(ctx, uid, payload)
+	} else if g.svc.ChatHub != nil {
+		g.svc.ChatHub.PushJSON(uid, payload)
 	}
-	if s.EventHook != nil {
+	if g.svc.EventHook != nil {
 		if m, ok := payload.(map[string]interface{}); ok {
-			s.EventHook(uid, m)
+			g.svc.EventHook(uid, m)
 		}
 	}
 }
 
 // publishControl routes a cross-instance generation control command to the
 // owner (no-op without a relay).
-func (s *AgentService) publishControl(ctx context.Context, uid uint64, payload interface{}) {
-	if s == nil || uid == 0 || s.Relay == nil {
+func (g *AgentGenerationService) publishControl(ctx context.Context, uid uint64, payload interface{}) {
+	if g.svc == nil || uid == 0 || g.svc.Relay == nil {
 		return
 	}
-	_ = s.Relay.PublishControl(ctx, uid, payload)
+	_ = g.svc.Relay.PublishControl(ctx, uid, payload)
 }
 
 // draftText returns the full text streamed so far for the user's generation.
 // It survives endGeneration (copied to the sticky last-draft slot) so a
 // re-prompt fallback can continue from the exact server-side draft.
-func (s *AgentService) draftText(uid uint64) string {
+func (g *AgentGenerationService) draftText(uid uint64) string {
 	if uid == 0 {
 		return ""
 	}
-	if st := s.generationState(uid); st != nil {
+	if st := g.svc.generationState(uid); st != nil {
 		st.mu.Lock()
 		defer st.mu.Unlock()
 		return strings.Join(st.draft, "")
 	}
-	s.draftMu.Lock()
-	defer s.draftMu.Unlock()
-	return s.lastDraft[uid]
+	g.svc.draftMu.Lock()
+	defer g.svc.draftMu.Unlock()
+	return g.svc.lastDraft[uid]
 }
 
 // currentGenID returns the generation id registered for the user, or 0.
-func (s *AgentService) currentGenID(uid uint64) uint64 {
-	st := s.generationState(uid)
+func (g *AgentGenerationService) currentGenID(uid uint64) uint64 {
+	st := g.svc.generationState(uid)
 	if st == nil {
 		return 0
 	}
@@ -132,60 +132,60 @@ func (s *AgentService) currentGenID(uid uint64) uint64 {
 	return st.genID
 }
 
-func (s *AgentService) generationState(uid uint64) *agentGenState {
+func (g *AgentGenerationService) generationState(uid uint64) *agentGenState {
 	if uid == 0 {
 		return nil
 	}
-	s.genMu.Lock()
-	defer s.genMu.Unlock()
-	if s.genStates == nil {
+	g.svc.genMu.Lock()
+	defer g.svc.genMu.Unlock()
+	if g.svc.genStates == nil {
 		return nil
 	}
-	return s.genStates[uid]
+	return g.svc.genStates[uid]
 }
 
 // beginGeneration registers a new generation state before the LLM call and
 // returns its generation id. The cancel func is owned by the state: it is
 // invoked when the generation is superseded, ended, or finished while paused,
 // and supersedes any previous generation state for the user.
-func (s *AgentService) beginGeneration(uid uint64, cancel context.CancelFunc) uint64 {
+func (g *AgentGenerationService) beginGeneration(uid uint64, cancel context.CancelFunc) uint64 {
 	if uid == 0 {
 		return 0
 	}
-	s.genMu.Lock()
-	if s.genStates == nil {
-		s.genStates = make(map[uint64]*agentGenState)
+	g.svc.genMu.Lock()
+	if g.svc.genStates == nil {
+		g.svc.genStates = make(map[uint64]*agentGenState)
 	}
-	s.genSeq++
-	old := s.genStates[uid]
-	s.genStates[uid] = &agentGenState{genID: s.genSeq, cancel: cancel, running: true}
-	s.genMu.Unlock()
+	g.svc.genSeq++
+	old := g.svc.genStates[uid]
+	g.svc.genStates[uid] = &agentGenState{genID: g.svc.genSeq, cancel: cancel, running: true}
+	g.svc.genMu.Unlock()
 	if old != nil {
 		if oldCancel := old.finish(); oldCancel != nil {
 			oldCancel()
 		}
 	}
-	s.clearDraft(uid)
-	return s.genSeq
+	g.svc.clearDraft(uid)
+	return g.svc.genSeq
 }
 
 // endGeneration removes the generation state only if it still belongs to the
 // given generation id (a finished goroutine can never clear a newer state).
 // The attached cancel is invoked so request resources are released.
-func (s *AgentService) endGeneration(uid uint64, genID uint64) {
+func (g *AgentGenerationService) endGeneration(uid uint64, genID uint64) {
 	if uid == 0 {
 		return
 	}
-	s.genMu.Lock()
-	st, ok := s.genStates[uid]
+	g.svc.genMu.Lock()
+	st, ok := g.svc.genStates[uid]
 	if !ok || st.genID != genID {
-		s.genMu.Unlock()
+		g.svc.genMu.Unlock()
 		return
 	}
-	delete(s.genStates, uid)
-	s.genMu.Unlock()
-	s.clearSnapshot(uid, genID)
-	s.saveDraft(uid, st)
+	delete(g.svc.genStates, uid)
+	g.svc.genMu.Unlock()
+	g.svc.clearSnapshot(uid, genID)
+	g.svc.saveDraft(uid, st)
 	if cancel := st.finish(); cancel != nil {
 		cancel()
 	}
@@ -221,7 +221,7 @@ func (st *agentGenState) ensureCond() {
 // saveDraft copies the generation's accumulated draft into the sticky
 // last-draft slot so a re-prompt fallback can continue from it after the
 // generation state is gone.
-func (s *AgentService) saveDraft(uid uint64, st *agentGenState) {
+func (g *AgentGenerationService) saveDraft(uid uint64, st *agentGenState) {
 	if st == nil {
 		return
 	}
@@ -231,36 +231,36 @@ func (s *AgentService) saveDraft(uid uint64, st *agentGenState) {
 	if draft == "" {
 		return
 	}
-	s.draftMu.Lock()
-	defer s.draftMu.Unlock()
-	if s.lastDraft == nil {
-		s.lastDraft = make(map[uint64]string)
+	g.svc.draftMu.Lock()
+	defer g.svc.draftMu.Unlock()
+	if g.svc.lastDraft == nil {
+		g.svc.lastDraft = make(map[uint64]string)
 	}
-	s.lastDraft[uid] = draft
+	g.svc.lastDraft[uid] = draft
 }
 
 // clearDraft removes the sticky last-draft slot for the user (a new generation
 // or a supersede invalidates any previous draft).
-func (s *AgentService) clearDraft(uid uint64) {
-	s.draftMu.Lock()
-	delete(s.lastDraft, uid)
-	s.draftMu.Unlock()
+func (g *AgentGenerationService) clearDraft(uid uint64) {
+	g.svc.draftMu.Lock()
+	delete(g.svc.lastDraft, uid)
+	g.svc.draftMu.Unlock()
 }
 
 // supersedeGeneration cancels and drops the user's current generation,
 // discarding its buffered deltas and any paused-completed reply that has not
 // been persisted yet. The dropped state stays registered so late deltas from
 // the old stream are still recognized and discarded.
-func (s *AgentService) supersedeGeneration(uid uint64) {
+func (g *AgentGenerationService) supersedeGeneration(uid uint64) {
 	if uid == 0 {
 		return
 	}
-	s.genMu.Lock()
-	if s.genStates == nil {
-		s.genStates = make(map[uint64]*agentGenState)
+	g.svc.genMu.Lock()
+	if g.svc.genStates == nil {
+		g.svc.genStates = make(map[uint64]*agentGenState)
 	}
-	st := s.genStates[uid]
-	s.genMu.Unlock()
+	st := g.svc.genStates[uid]
+	g.svc.genMu.Unlock()
 	if st == nil {
 		return
 	}
@@ -277,30 +277,30 @@ func (s *AgentService) supersedeGeneration(uid uint64) {
 	cancel := st.cancel
 	st.cancel = nil
 	st.mu.Unlock()
-	s.clearDraft(uid)
+	g.svc.clearDraft(uid)
 	if cancel != nil {
 		cancel()
 	}
-	s.clearSnapshot(uid, genID)
+	g.svc.clearSnapshot(uid, genID)
 }
 
 // dropCurrentGeneration marks the user's current generation as dropped (its
 // buffered/live deltas are discarded). The state stays registered so late
 // deltas from the old stream are still recognized and dropped.
-func (s *AgentService) dropCurrentGeneration(uid uint64) {
+func (g *AgentGenerationService) dropCurrentGeneration(uid uint64) {
 	if uid == 0 {
 		return
 	}
-	s.genMu.Lock()
-	if s.genStates == nil {
-		s.genStates = make(map[uint64]*agentGenState)
+	g.svc.genMu.Lock()
+	if g.svc.genStates == nil {
+		g.svc.genStates = make(map[uint64]*agentGenState)
 	}
-	st := s.genStates[uid]
+	st := g.svc.genStates[uid]
 	if st == nil {
 		st = &agentGenState{}
-		s.genStates[uid] = st
+		g.svc.genStates[uid] = st
 	}
-	s.genMu.Unlock()
+	g.svc.genMu.Unlock()
 	st.mu.Lock()
 	st.dropped = true
 	if st.cond != nil {
@@ -312,11 +312,11 @@ func (s *AgentService) dropCurrentGeneration(uid uint64) {
 // hasRunningGeneration reports whether a generation goroutine is still active
 // for the user (used by resume to decide whether buffered deltas are enough or
 // a completed reply needs to be persisted).
-func (s *AgentService) hasRunningGeneration(uid uint64) bool {
+func (g *AgentGenerationService) hasRunningGeneration(uid uint64) bool {
 	if uid == 0 {
 		return false
 	}
-	st := s.generationState(uid)
+	st := g.svc.generationState(uid)
 	if st == nil {
 		return false
 	}
@@ -328,13 +328,13 @@ func (s *AgentService) hasRunningGeneration(uid uint64) bool {
 // storePendingReply records a reply that completed while the user had paused
 // the stream. The generation is marked finished (its cancel is released) but
 // its state stays registered so a resume can flush buffered deltas first.
-func (s *AgentService) storePendingReply(uid uint64, genID uint64, conv *dm.DmConversation, result *GenerateReplyResult) {
+func (g *AgentGenerationService) storePendingReply(uid uint64, genID uint64, conv *dm.DmConversation, result *GenerateReplyResult) {
 	if uid == 0 || genID == 0 || conv == nil || result == nil {
 		return
 	}
-	s.genMu.Lock()
-	st := s.genStates[uid]
-	s.genMu.Unlock()
+	g.svc.genMu.Lock()
+	st := g.svc.genStates[uid]
+	g.svc.genMu.Unlock()
 	if st == nil || st.genID != genID {
 		return
 	}
@@ -345,7 +345,7 @@ func (s *AgentService) storePendingReply(uid uint64, genID uint64, conv *dm.DmCo
 	cancel := st.cancel
 	st.cancel = nil
 	st.mu.Unlock()
-	s.snapshotPending(uid, curGenID, conv.ID, result)
+	g.svc.snapshotPending(uid, curGenID, conv.ID, result)
 	if cancel != nil {
 		cancel()
 	}
@@ -353,13 +353,13 @@ func (s *AgentService) storePendingReply(uid uint64, genID uint64, conv *dm.DmCo
 
 // takePendingReply consumes the user's paused-completed reply, returning the
 // conversation, result and generation id. The second call returns false.
-func (s *AgentService) takePendingReply(uid uint64) (*dm.DmConversation, *GenerateReplyResult, uint64, bool) {
+func (g *AgentGenerationService) takePendingReply(uid uint64) (*dm.DmConversation, *GenerateReplyResult, uint64, bool) {
 	if uid == 0 {
 		return nil, nil, 0, false
 	}
-	s.genMu.Lock()
-	st := s.genStates[uid]
-	s.genMu.Unlock()
+	g.svc.genMu.Lock()
+	st := g.svc.genStates[uid]
+	g.svc.genMu.Unlock()
 	if st == nil {
 		return nil, nil, 0, false
 	}
@@ -378,52 +378,52 @@ func (s *AgentService) takePendingReply(uid uint64) (*dm.DmConversation, *Genera
 // PauseGeneration pauses the user's generation. A generation owned locally is
 // paused in place; when it runs on another replica, the control command is
 // routed to the owner via Redis.
-func (s *AgentService) PauseGeneration(uid uint64) {
-	if s == nil || uid == 0 {
+func (g *AgentGenerationService) PauseGeneration(uid uint64) {
+	if g.svc == nil || uid == 0 {
 		return
 	}
-	if s.hasRunningGeneration(uid) {
-		s.pauseGeneration(uid)
+	if g.svc.hasRunningGeneration(uid) {
+		g.svc.pauseGeneration(uid)
 		return
 	}
-	s.publishControl(context.Background(), uid, map[string]interface{}{"type": "pause", "from": s.InstanceID})
+	g.svc.publishControl(context.Background(), uid, map[string]interface{}{"type": "pause", "from": g.svc.InstanceID})
 }
 
 // pauseGeneration stops pushing streamed deltas; they are buffered so a later
 // resumeGeneration can flush them verbatim (byte-level continuation).
-func (s *AgentService) pauseGeneration(uid uint64) {
+func (g *AgentGenerationService) pauseGeneration(uid uint64) {
 	if uid == 0 {
 		return
 	}
-	s.genMu.Lock()
-	if s.genStates == nil {
-		s.genStates = make(map[uint64]*agentGenState)
+	g.svc.genMu.Lock()
+	if g.svc.genStates == nil {
+		g.svc.genStates = make(map[uint64]*agentGenState)
 	}
-	st := s.genStates[uid]
+	st := g.svc.genStates[uid]
 	if st == nil {
 		st = &agentGenState{}
-		s.genStates[uid] = st
+		g.svc.genStates[uid] = st
 	}
-	s.genMu.Unlock()
+	g.svc.genMu.Unlock()
 	st.mu.Lock()
 	st.paused = true
 	st.pauseSeq++
 	genID := st.genID
 	pauseSeq := st.pauseSeq
 	st.mu.Unlock()
-	s.updateSnapshotPaused(uid, genID, true, pauseSeq)
+	g.svc.updateSnapshotPaused(uid, genID, true, pauseSeq)
 }
 
 // resumeGeneration un-pauses and flushes the buffered deltas in order.
-func (s *AgentService) resumeGeneration(uid uint64) {
+func (g *AgentGenerationService) resumeGeneration(uid uint64) {
 	if uid == 0 {
 		return
 	}
-	if s.ChatHub == nil && s.Relay == nil {
+	if g.svc.ChatHub == nil && g.svc.Relay == nil {
 		return
 	}
 	for {
-		st := s.generationState(uid)
+		st := g.svc.generationState(uid)
 		if st == nil {
 			return
 		}
@@ -471,7 +471,7 @@ func (s *AgentService) resumeGeneration(uid uint64) {
 				return
 			}
 			st.mu.Unlock()
-			s.publishEvent(context.Background(), uid, map[string]interface{}{
+			g.svc.publishEvent(context.Background(), uid, map[string]interface{}{
 				"type": "agent_delta",
 				"body": map[string]interface{}{"content": d},
 			})
@@ -507,14 +507,14 @@ func (s *AgentService) resumeGeneration(uid uint64) {
 		}
 		st.paused = false
 		st.mu.Unlock()
-		s.updateSnapshotPaused(uid, st.genID, false, seq)
+		g.svc.updateSnapshotPaused(uid, st.genID, false, seq)
 		return
 	}
 }
 
 // isGenerationPaused reports whether the user's generation is paused.
-func (s *AgentService) isGenerationPaused(uid uint64) bool {
-	st := s.generationState(uid)
+func (g *AgentGenerationService) isGenerationPaused(uid uint64) bool {
+	st := g.svc.generationState(uid)
 	if st == nil {
 		return false
 	}
@@ -524,12 +524,12 @@ func (s *AgentService) isGenerationPaused(uid uint64) bool {
 }
 
 // clearGenerationState removes the user's pause/buffer state.
-func (s *AgentService) clearGenerationState(uid uint64) {
+func (g *AgentGenerationService) clearGenerationState(uid uint64) {
 	if uid == 0 {
 		return
 	}
-	s.genMu.Lock()
-	defer s.genMu.Unlock()
-	delete(s.genStates, uid)
-	s.clearDraft(uid)
+	g.svc.genMu.Lock()
+	defer g.svc.genMu.Unlock()
+	delete(g.svc.genStates, uid)
+	g.svc.clearDraft(uid)
 }

--- a/internal/service/agent/agent_tools.go
+++ b/internal/service/agent/agent_tools.go
@@ -16,13 +16,13 @@ import (
 )
 
 // enabledTools builds the tool enabled map from RuntimeConfig.
-func (s *AgentService) enabledTools() map[string]bool {
+func (g *AgentGenerationService) enabledTools() map[string]bool {
 	m := make(map[string]bool)
 	for _, name := range toolkit.AllToolNames() {
 		enabled := true
-		if s.RC != nil {
+		if g.svc.RC != nil {
 			key := "tool_" + name + "_enabled"
-			enabled = s.RC.GetBool(key, true)
+			enabled = g.svc.RC.GetBool(key, true)
 		}
 		m[name] = enabled
 	}
@@ -38,14 +38,14 @@ func generateTraceID() string {
 	return hex.EncodeToString(b)
 }
 
-func (s *AgentService) setupToolCallbacks(traceID string, humanID uint64) {
-	if s.Gateway == nil || s.ChatHub == nil {
+func (g *AgentGenerationService) setupToolCallbacks(traceID string, humanID uint64) {
+	if g.svc.Gateway == nil || g.svc.ChatHub == nil {
 		return
 	}
-	s.Gateway.OnToolCallStart = func(tid, spanID, parentSpanID, toolName string, argsJSON json.RawMessage) {
+	g.svc.Gateway.OnToolCallStart = func(tid, spanID, parentSpanID, toolName string, argsJSON json.RawMessage) {
 		var args interface{}
-		if err := json.Unmarshal(argsJSON, &args); err != nil && s.Log != nil {
-			s.Log.Warn("agent: parse tool call args failed", zap.String("tool", toolName), zap.Error(err))
+		if err := json.Unmarshal(argsJSON, &args); err != nil && g.svc.Log != nil {
+			g.svc.Log.Warn("agent: parse tool call args failed", zap.String("tool", toolName), zap.Error(err))
 		}
 		payload := map[string]interface{}{
 			"trace_id":       tid,
@@ -55,12 +55,12 @@ func (s *AgentService) setupToolCallbacks(traceID string, humanID uint64) {
 			"arguments":      args,
 			"started_at":     time.Now().Format(time.RFC3339),
 		}
-		s.ChatHub.PushJSON(humanID, map[string]interface{}{
+		g.svc.ChatHub.PushJSON(humanID, map[string]interface{}{
 			"type": "tool_call_start",
 			"body": payload,
 		})
 	}
-	s.Gateway.OnToolCallEnd = func(tid, spanID, toolName string, durationMs int64, resultSummary string) {
+	g.svc.Gateway.OnToolCallEnd = func(tid, spanID, toolName string, durationMs int64, resultSummary string) {
 		payload := map[string]interface{}{
 			"trace_id":       tid,
 			"span_id":        spanID,
@@ -68,30 +68,30 @@ func (s *AgentService) setupToolCallbacks(traceID string, humanID uint64) {
 			"duration_ms":    durationMs,
 			"result_summary": resultSummary,
 		}
-		s.ChatHub.PushJSON(humanID, map[string]interface{}{
+		g.svc.ChatHub.PushJSON(humanID, map[string]interface{}{
 			"type": "tool_call_end",
 			"body": payload,
 		})
 	}
-	s.Gateway.OnToolResultData = func(tid, spanID, toolName string, items json.RawMessage) {
+	g.svc.Gateway.OnToolResultData = func(tid, spanID, toolName string, items json.RawMessage) {
 		payload := map[string]interface{}{
 			"trace_id":  tid,
 			"span_id":   spanID,
 			"tool_name": toolName,
 			"items":     items,
 		}
-		s.ChatHub.PushJSON(humanID, map[string]interface{}{
+		g.svc.ChatHub.PushJSON(humanID, map[string]interface{}{
 			"type": "tool_result_data",
 			"body": payload,
 		})
 	}
 }
 
-func (s *AgentService) clearToolCallbacks() {
-	if s.Gateway != nil {
-		s.Gateway.OnToolCallStart = nil
-		s.Gateway.OnToolCallEnd = nil
-		s.Gateway.OnToolResultData = nil
+func (g *AgentGenerationService) clearToolCallbacks() {
+	if g.svc.Gateway != nil {
+		g.svc.Gateway.OnToolCallStart = nil
+		g.svc.Gateway.OnToolCallEnd = nil
+		g.svc.Gateway.OnToolResultData = nil
 	}
 }
 

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Dependency direction guard: keeps the Kratos-ward layering intact.
+#
+# Rules (add future ones here, e.g. for cakecake/api when it exists):
+#   handler must not import internal/data
+#   service must not import internal/handler
+#   client must not import gorm
+#   model must not import internal/service or internal/data
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+go list -f '{{.ImportPath}}|{{join .Imports " "}}' ./internal/... 2>&1 |
+	awk -F'|' '
+	{
+		n = split($2, imps, " ")
+		for (i = 1; i <= n; i++) {
+			imp = imps[i]
+			if ($1 ~ /^cakecake\/internal\/handler/ && imp ~ /^cakecake\/internal\/data/) {
+				print "handler -> data: " $1 " imports " imp; bad = 1
+			}
+			if ($1 ~ /^cakecake\/internal\/service/ && imp ~ /^cakecake\/internal\/handler/) {
+				print "service -> handler: " $1 " imports " imp; bad = 1
+			}
+			if ($1 == "cakecake/internal/client" && imp ~ /^gorm\.io\/gorm/) {
+				print "client -> gorm: " $1 " imports " imp; bad = 1
+			}
+			if ($1 ~ /^cakecake\/internal\/model/ && imp ~ /^cakecake\/internal\/(service|data)/) {
+				print "model -> service/data: " $1 " imports " imp; bad = 1
+			}
+			# Future: transport must not import model directly once api/ DTOs exist.
+			# if ($1 ~ /^cakecake\/internal\/handler/ && imp ~ /^cakecake\/api\//) { ... }
+		}
+	}
+	END { if (bad) exit 1 }
+	'


### PR DESCRIPTION
## Summary

Three incremental refactors toward Kratos-style layering on top of the
existing `feat/ai-assistant-streaming` work. No behavioral changes; the
public surfaces (routes, handler signatures, AgentService fields) stay
identical.

## Changes

1. **CI dependency direction guard** (`scripts/check_deps.sh`, wired into
   `.github/workflows/ci.yml`)
   Uses `go list` to enforce four layering rules so the ongoing migration
   cannot regress:
   - `handler` must not import `internal/data`
   - `service` must not import `internal/handler`
   - `client` must not import `gorm`
   - `model` must not import `internal/service` or `internal/data`
   A placeholder is reserved for the future `cakecake/api` package.

2. **AgentService split into domain facades** (`internal/service/agent`)
   The 83 methods of the oversized `AgentService` are regrouped into three
   cohesive types:
   - `AgentGenerationService` — 58 methods (orchestration, state,
     tool-calling, snapshot)
   - `AgentProfileService` — 22 methods (profiles)
   - `AgentFeedbackService` — 3 methods (feedback)
   `AgentService` keeps all 21 fields and now forwards via a thin
   `agent_facade.go`, so no call site or test changes were required.

3. **aigateway `Gateway` decomposition** (`internal/aigateway`)
   The 10-field `Gateway` is split into `HistoryStore` (6 methods:
   history key/persist/build/clear/TTL) and `ToolRunner` (1 method:
   `executeToolCalls`). `Gateway` retains 13 methods (6 direct
   implementations + 7 forwarders). Its LCOM drops enough to leave the
   worst-15 coupling list.

## Verification

- `go build ./...`, `go vet`, `gofmt` — clean
- `golangci-lint` — 0 findings
- Full integration suite `go test -tags=integration ./internal/... ./cmd/...`
  — all packages pass
- Dependency guard verified both ways: passes on current code, exits 1 on
  constructed violations