### PR TITLE
feat(ai): make global agent system prompt admin-editable

### DIFF
--- a/cakecake-vue/cakecake-web/src/pages/admin/AgentManage.vue
+++ b/cakecake-vue/cakecake-web/src/pages/admin/AgentManage.vue
@@ -38,6 +38,28 @@
       title="未配置 DEEPSEEK_API_KEY，用户发消息后将收到未配置提示。"
     />
 
+    <section class="ai-global-prompt" v-if="settingsLoaded">
+      <div class="ai-global-prompt__head">
+        <div>
+          <h4>通用提示词（全局层）</h4>
+          <p class="ai-global-prompt__tip">
+            作用于所有角色，各角色的「角色人设」在其之上叠加；保存后从下一次回复开始生效，不会被服务重启覆盖。
+          </p>
+        </div>
+        <el-button type="primary" :loading="globalSaving" @click="saveGlobalPrompt">
+          保存通用提示词
+        </el-button>
+      </div>
+      <el-input
+        v-model="globalPrompt"
+        type="textarea"
+        :rows="8"
+        maxlength="12000"
+        show-word-limit
+        placeholder="所有角色共用的 DeepSeek system 提示词"
+      />
+    </section>
+
     <div class="ai-hub__toolbar">
       <span class="ai-hub__toolbar-hint">最多 {{ maxProfiles }} 个角色</span>
       <el-button
@@ -237,7 +259,9 @@
 import {
   adminCreateAgentProfile,
   adminDeleteAgentProfile,
+  adminGetAgentSettings,
   adminListAgentProfiles,
+  adminPutAgentSettings,
   adminUpdateAgentProfile,
   adminUploadAgentProfileAvatar
 } from "@/api/admin";
@@ -266,8 +290,12 @@ export default {
       avatarCropVisible: false,
       avatarCropSrc: "",
       avatarCropFileName: "agent-avatar.jpg",
-      _avatarCropObjectUrl: null,
-      form: this.emptyForm()
+      avatarCropObjectUrl: null,
+      form: this.emptyForm(),
+      globalPrompt: "",
+      globalSaving: false,
+      settingsLoaded: false,
+      settings: null
     };
   },
   computed: {
@@ -321,10 +349,41 @@ export default {
         this.profiles = d.items || [];
         this.maxProfiles = d.max_profiles || 12;
         this.deepseekConfigured = d.deepseek_configured !== false;
+        try {
+          const sbody = await adminGetAgentSettings();
+          const sd = (sbody && sbody.data) || {};
+          this.settings = sd;
+          this.globalPrompt = String(sd.global_system_prompt || "").trim();
+          this.settingsLoaded = true;
+        } catch (e) {
+          // Global prompt is a secondary section; profile list still works.
+        }
       } catch (e) {
         ElMessage.error((e && e.message) || "加载失败");
       } finally {
         this.loading = false;
+      }
+    },
+    async saveGlobalPrompt() {
+      const text = String(this.globalPrompt || "").trim();
+      if (text.length < 10) {
+        ElMessage.warning("通用提示词至少 10 个字");
+        return;
+      }
+      if (text.length > 12000) {
+        ElMessage.warning("通用提示词不能超过 12000 字");
+        return;
+      }
+      this.globalSaving = true;
+      try {
+        // Only the global field is submitted: a stale page snapshot of the
+        // role fields must never overwrite unsaved role edits.
+        await adminPutAgentSettings({ global_system_prompt: text });
+        ElMessage.success("通用提示词已保存，从下一次回复开始生效");
+      } catch (e) {
+        ElMessage.error((e && e.message) || "保存失败");
+      } finally {
+        this.globalSaving = false;
       }
     },
     openCreate() {
@@ -484,9 +543,9 @@ export default {
       }
     },
     closeAvatarCrop() {
-      if (this._avatarCropObjectUrl) {
-        URL.revokeObjectURL(this._avatarCropObjectUrl);
-        this._avatarCropObjectUrl = null;
+      if (this.avatarCropObjectUrl) {
+        URL.revokeObjectURL(this.avatarCropObjectUrl);
+        this.avatarCropObjectUrl = null;
       }
       this.avatarCropVisible = false;
       this.avatarCropSrc = "";
@@ -520,7 +579,7 @@ export default {
       }
       this.closeAvatarCrop();
       const url = URL.createObjectURL(file);
-      this._avatarCropObjectUrl = url;
+      this.avatarCropObjectUrl = url;
       this.avatarCropSrc = url;
       this.avatarCropFileName = name || "agent-avatar.jpg";
       this.avatarCropVisible = true;
@@ -819,5 +878,29 @@ export default {
 }
 .adm-upload__input {
   display: none;
+}
+.ai-global-prompt {
+  margin: 16px 0;
+  padding: 16px;
+  border: 1px solid var(--el-border-color, #e4e7ed);
+  border-radius: 10px;
+  background: #fff;
+}
+.ai-global-prompt__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+.ai-global-prompt__head h4 {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+.ai-global-prompt__tip {
+  margin: 0;
+  font-size: 12px;
+  color: #909399;
+  line-height: 1.6;
 }
 </style>

--- a/internal/client/Agent.go
+++ b/internal/client/Agent.go
@@ -40,6 +40,7 @@ type Agent interface {
 	RenameAgentProfileSlug(ctx context.Context, p *agent.AgentProfile, newSlug string) error
 	SyncAgentProfile(ctx context.Context, p *agent.AgentProfile) error
 	UnmarshalWelcomeList(raw json.RawMessage, fallback []string) ([]string, error)
+	UpdateGlobalSystemPrompt(ctx context.Context, prompt string) error
 	UpdateAgentAvatar(ctx context.Context, id uint64, avatarURL string) error
 	UpdateAgentProfile(ctx context.Context, id uint64, updates map[string]interface{}) error
 }

--- a/internal/data/agent_settings.go
+++ b/internal/data/agent_settings.go
@@ -7,6 +7,7 @@ import (
 
 	"go.uber.org/zap"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const defaultAgentDisplayName = "cakecake AI"
@@ -30,6 +31,9 @@ const defaultAgentSystemPrompt = `你是 cakecake 站内 AI 助手。帮助用�
 - 不确定时诚实说不知道`
 
 // EnsureDefaultAgentSettings creates the singleton settings row when missing.
+// The code constant is the DEFAULT for fresh environments only: once the row
+// exists, the database is the single source of truth (admin edits must never
+// be reverted by a startup sync).
 func EnsureDefaultAgentSettings(db *gorm.DB, lg *zap.Logger) error {
 	if db == nil {
 		return nil
@@ -37,14 +41,7 @@ func EnsureDefaultAgentSettings(db *gorm.DB, lg *zap.Logger) error {
 	var st agent.AgentSettings
 	err := db.First(&st, agent.AgentSettingsRowID).Error
 	if err == nil {
-		// Always sync global prompt from code constant on startup
-		st.SystemPrompt = defaultAgentSystemPrompt
-		if err := db.Model(&st).Update("system_prompt", st.SystemPrompt).Error; err != nil && lg != nil {
-			lg.Warn("sync agent_settings system_prompt failed", zap.Error(err))
-		}
-		if lg != nil {
-			lg.Info("synced agent_settings system_prompt from code constant")
-		}
+		// Row already exists: keep whatever is stored (admin edits persist).
 		return nil
 	}
 	if err != gorm.ErrRecordNotFound {
@@ -115,4 +112,30 @@ func GetGlobalSystemPrompt(db *gorm.DB) string {
 		return v
 	}
 	return defaultAgentSystemPrompt
+}
+
+// UpdateGlobalAgentSettings overwrites the global (all-role) system prompt via
+// an INSERT ... ON CONFLICT(id) DO UPDATE upsert.
+//
+// It must NOT use RowsAffected to detect a missing row: MySQL (without
+// clientFoundRows) reports 0 affected rows when the new value equals the
+// stored one, which would wrongly trigger a duplicate Create and a primary-key
+// conflict. On insert the defaults are seeded; on conflict only system_prompt
+// is updated so the other settings are preserved.
+func UpdateGlobalAgentSettings(db *gorm.DB, systemPrompt string) error {
+	if db == nil {
+		return gorm.ErrRecordNotFound
+	}
+	prompt := strings.TrimSpace(systemPrompt)
+	return db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"system_prompt"}),
+	}).Create(&agent.AgentSettings{
+		ID:               agent.AgentSettingsRowID,
+		DisplayName:      defaultAgentDisplayName,
+		Sign:             defaultAgentSign,
+		SystemPrompt:     prompt,
+		WelcomeMessage:   defaultAgentWelcome,
+		AssistantEnabled: true,
+	}).Error
 }

--- a/internal/data/agent_settings_test.go
+++ b/internal/data/agent_settings_test.go
@@ -39,11 +39,46 @@ func TestEnsureDefaultAgentSettings_Creates(t *testing.T) {
 func TestEnsureDefaultAgentSettings_AlreadyExists(t *testing.T) {
 	db := newAgentSettingsDB(t)
 	require.NoError(t, EnsureDefaultAgentSettings(db, zap.NewNop()))
+	// Admin edits the global prompt; a restart must NOT revert it.
+	require.NoError(t, UpdateGlobalAgentSettings(db, "custom global prompt"))
 	require.NoError(t, EnsureDefaultAgentSettings(db, zap.NewNop()))
 
 	var count int64
 	db.Model(&agent.AgentSettings{}).Count(&count)
 	assert.Equal(t, int64(1), count)
+	var st agent.AgentSettings
+	require.NoError(t, db.First(&st, agent.AgentSettingsRowID).Error)
+	assert.Equal(t, "custom global prompt", st.SystemPrompt)
+}
+
+func TestUpdateGlobalAgentSettings(t *testing.T) {
+	db := newAgentSettingsDB(t)
+	require.NoError(t, EnsureDefaultAgentSettings(db, zap.NewNop()))
+	require.NoError(t, UpdateGlobalAgentSettings(db, "  新的全局提示词  "))
+
+	var st agent.AgentSettings
+	require.NoError(t, db.First(&st, agent.AgentSettingsRowID).Error)
+	assert.Equal(t, "新的全局提示词", st.SystemPrompt)
+
+	require.Error(t, UpdateGlobalAgentSettings(nil, "x"))
+}
+
+// Regression: MySQL reports 0 affected rows when the new value equals the
+// stored one. The upsert must never misread that as "row missing" and attempt
+// a duplicate Create (primary-key conflict).
+func TestUpdateGlobalAgentSettings_SameValueTwice(t *testing.T) {
+	db := newAgentSettingsDB(t)
+	require.NoError(t, EnsureDefaultAgentSettings(db, zap.NewNop()))
+	require.NoError(t, UpdateGlobalAgentSettings(db, "unchanged prompt"))
+	require.NoError(t, UpdateGlobalAgentSettings(db, "unchanged prompt"))
+
+	var count int64
+	require.NoError(t, db.Model(&agent.AgentSettings{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+
+	var st agent.AgentSettings
+	require.NoError(t, db.First(&st, agent.AgentSettingsRowID).Error)
+	assert.Equal(t, "unchanged prompt", st.SystemPrompt)
 }
 
 func TestEnsureDefaultAgentSettings_NilDB(t *testing.T) {

--- a/internal/handler/admin_agent.go
+++ b/internal/handler/admin_agent.go
@@ -55,6 +55,7 @@ type adminAgentSettingsResponse struct {
 	AvatarURL          string `json:"avatar_url"`
 	Sign               string `json:"sign"`
 	SystemPrompt       string `json:"system_prompt"`
+	GlobalSystemPrompt string `json:"global_system_prompt"`
 	WelcomeMessage     string `json:"welcome_message"`
 	AssistantEnabled   bool   `json:"assistant_enabled"`
 	BotUserID          uint64 `json:"bot_user_id"`
@@ -394,6 +395,7 @@ func (a *API) AdminGetAgentSettings(c *gin.Context) {
 		AvatarURL:          p.AvatarURL,
 		Sign:               p.Sign,
 		SystemPrompt:       p.SystemPrompt,
+		GlobalSystemPrompt: a.Agent.GetGlobalSystemPrompt(ctx),
 		WelcomeMessage:     welcomeOne,
 		AssistantEnabled:   p.Enabled,
 		BotUserID:          p.BotUserID,
@@ -405,60 +407,84 @@ func (a *API) AdminGetAgentSettings(c *gin.Context) {
 // AdminPutAgentSettings updates the global agent settings.
 func (a *API) AdminPutAgentSettings(c *gin.Context) {
 	ctx := c.Request.Context()
-	list, _ := a.Agent.ListAgentProfiles(ctx)
-	if len(list) == 0 {
-		resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
-		return
-	}
-	c.Params = append(c.Params, gin.Param{Key: "id", Value: strconv.FormatUint(list[0].ID, 10)})
 	var req adminAgentSettingsReq
 	if err := c.ShouldBindJSON(&req); err != nil {
 		resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
 		return
 	}
-	welcomeRaw, _ := json.Marshal([]string{strings.TrimSpace(req.WelcomeMessage)})
-	write := adminAgentProfileWriteReq{
-		DisplayName:     req.DisplayName,
-		AvatarURL:       req.AvatarURL,
-		Sign:            req.Sign,
-		SystemPrompt:    req.SystemPrompt,
-		WelcomeMessages: welcomeRaw,
+	// The admin UI saves the shared prompt independently from role fields.
+	// When ONLY global_system_prompt is provided, skip the profile path so a
+	// stale page snapshot can never overwrite unsaved role edits.
+	globalOnly := req.GlobalSystemPrompt != nil &&
+		strings.TrimSpace(req.DisplayName) == "" &&
+		strings.TrimSpace(req.SystemPrompt) == "" &&
+		strings.TrimSpace(req.WelcomeMessage) == "" &&
+		strings.TrimSpace(req.AvatarURL) == "" &&
+		strings.TrimSpace(req.Sign) == "" &&
+		req.AssistantEnabled == nil
+	if !globalOnly {
+		list, _ := a.Agent.ListAgentProfiles(ctx)
+		if len(list) == 0 {
+			resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
+			return
+		}
+		c.Params = append(c.Params, gin.Param{Key: "id", Value: strconv.FormatUint(list[0].ID, 10)})
+		welcomeRaw, _ := json.Marshal([]string{strings.TrimSpace(req.WelcomeMessage)})
+		write := adminAgentProfileWriteReq{
+			DisplayName:     req.DisplayName,
+			AvatarURL:       req.AvatarURL,
+			Sign:            req.Sign,
+			SystemPrompt:    req.SystemPrompt,
+			WelcomeMessages: welcomeRaw,
+		}
+		if req.AssistantEnabled != nil {
+			write.Enabled = req.AssistantEnabled
+		}
+		_, welcomeJSON, code := a.validateAgentProfileWrite(&write, false)
+		if code != 0 {
+			resp.Err(c, http.StatusBadRequest, code)
+			return
+		}
+		p := list[0]
+		updates := map[string]interface{}{
+			"display_name":          strings.TrimSpace(req.DisplayName),
+			"avatar_url":            strings.TrimSpace(req.AvatarURL),
+			"sign":                  strings.TrimSpace(req.Sign),
+			"system_prompt":         strings.TrimSpace(req.SystemPrompt),
+			"welcome_messages_json": welcomeJSON,
+		}
+		if req.AssistantEnabled != nil {
+			updates["enabled"] = *req.AssistantEnabled
+		}
+		if err := a.Agent.UpdateAgentProfile(ctx, p.ID, updates); err != nil {
+			resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
+			return
+		}
+		p2, _ := a.Agent.GetAgentProfile(ctx, p.ID)
+		_ = a.Agent.SyncAgentProfile(ctx, p2)
 	}
-	if req.AssistantEnabled != nil {
-		write.Enabled = req.AssistantEnabled
+	if req.GlobalSystemPrompt != nil {
+		globalPrompt := strings.TrimSpace(*req.GlobalSystemPrompt)
+		if utf8.RuneCountInString(globalPrompt) > 12000 {
+			resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
+			return
+		}
+		if err := a.Agent.UpdateGlobalSystemPrompt(ctx, globalPrompt); err != nil {
+			resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
+			return
+		}
 	}
-	_, welcomeJSON, code := a.validateAgentProfileWrite(&write, false)
-	if code != 0 {
-		resp.Err(c, http.StatusBadRequest, code)
-		return
-	}
-	p := list[0]
-	updates := map[string]interface{}{
-		"display_name":          strings.TrimSpace(req.DisplayName),
-		"avatar_url":            strings.TrimSpace(req.AvatarURL),
-		"sign":                  strings.TrimSpace(req.Sign),
-		"system_prompt":         strings.TrimSpace(req.SystemPrompt),
-		"welcome_messages_json": welcomeJSON,
-	}
-	if req.AssistantEnabled != nil {
-		updates["enabled"] = *req.AssistantEnabled
-	}
-	if err := a.Agent.UpdateAgentProfile(ctx, p.ID, updates); err != nil {
-		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
-		return
-	}
-	p2, _ := a.Agent.GetAgentProfile(ctx, p.ID)
-	_ = a.Agent.SyncAgentProfile(ctx, p2)
 	a.AdminGetAgentSettings(c)
 }
 
 type adminAgentSettingsReq struct {
-	DisplayName      string `json:"display_name"`
-	AvatarURL        string `json:"avatar_url"`
-	Sign             string `json:"sign"`
-	SystemPrompt     string `json:"system_prompt"`
-	WelcomeMessage   string `json:"welcome_message"`
-	AssistantEnabled *bool  `json:"assistant_enabled"`
+	DisplayName        string  `json:"display_name"`
+	AvatarURL          string  `json:"avatar_url"`
+	Sign               string  `json:"sign"`
+	SystemPrompt       string  `json:"system_prompt"`
+	GlobalSystemPrompt *string `json:"global_system_prompt"`
+	WelcomeMessage     string  `json:"welcome_message"`
+	AssistantEnabled   *bool   `json:"assistant_enabled"`
 }
 
 // AdminUploadAgentAvatar uploads/replaces the agent avatar.

--- a/internal/handler/admin_api_test.go
+++ b/internal/handler/admin_api_test.go
@@ -146,6 +146,19 @@ func TestAdminEndpoints(t *testing.T) {
 	covOK(t, covReq(t, r, "GET", "/api/v1/admin/agent-profiles", at, nil), http.StatusOK)
 	covOK(t, covReq(t, r, "GET", "/api/v1/admin/agent-settings", at, nil), http.StatusOK)
 	covOK(t, covReq(t, r, "PUT", "/api/v1/admin/agent-settings", at, map[string]any{"system_prompt": "Please be nice to users.", "display_name": "Assistant", "welcome_message": "Hi!"}), http.StatusOK)
+	// Global-only update must not touch (or require) profile fields.
+	covOK(t, covReq(t, r, "PUT", "/api/v1/admin/agent-settings", at, map[string]any{"global_system_prompt": "Global prompt for all roles."}), http.StatusOK)
+	gs := covReq(t, r, "GET", "/api/v1/admin/agent-settings", at, nil)
+	covOK(t, gs, http.StatusOK)
+	var gsOut struct {
+		Data struct {
+			GlobalSystemPrompt string `json:"global_system_prompt"`
+			SystemPrompt       string `json:"system_prompt"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(gs.Body.Bytes(), &gsOut))
+	require.Equal(t, "Global prompt for all roles.", gsOut.Data.GlobalSystemPrompt)
+	require.Equal(t, "Please be nice to users.", gsOut.Data.SystemPrompt)
 	apw2 := covReq(t, r, "POST", "/api/v1/admin/agent-profiles", at, map[string]any{"slug": "assistant2", "display_name": "Assistant 2", "sign": "hi", "system_prompt": "Please help users with their questions.", "welcome_messages": []string{"Hello!"}})
 	covOK(t, apw2, http.StatusOK)
 	covOK(t, covReq(t, r, "PUT", "/api/v1/admin/agent-profiles/"+u64s(apOut.Data.ID), at, map[string]any{"display_name": "Renamed", "system_prompt": "Please be helpful and concise.", "welcome_messages": []string{"Hey!"}}), http.StatusOK)

--- a/internal/service/agent/agent_facade.go
+++ b/internal/service/agent/agent_facade.go
@@ -79,6 +79,11 @@ func (s *AgentService) GetGlobalSystemPrompt(ctx context.Context) string {
 	return (&AgentProfileService{svc: s}).GetGlobalSystemPrompt(ctx)
 }
 
+// UpdateGlobalSystemPrompt delegates to the corresponding domain service.
+func (s *AgentService) UpdateGlobalSystemPrompt(ctx context.Context, prompt string) error {
+	return (&AgentProfileService{svc: s}).UpdateGlobalSystemPrompt(ctx, prompt)
+}
+
 // ProfileCount delegates to the corresponding domain service.
 func (s *AgentService) ProfileCount(ctx context.Context) (int64, error) {
 	return (&AgentProfileService{svc: s}).ProfileCount(ctx)

--- a/internal/service/agent/agent_profiles.go
+++ b/internal/service/agent/agent_profiles.go
@@ -76,6 +76,11 @@ func (ps *AgentProfileService) GetGlobalSystemPrompt(ctx context.Context) string
 	return ps.svc.Store.GetGlobalSystemPrompt()
 }
 
+// UpdateGlobalSystemPrompt persists the global (all-role) system prompt.
+func (ps *AgentProfileService) UpdateGlobalSystemPrompt(ctx context.Context, prompt string) error {
+	return ps.svc.Store.UpdateGlobalSystemPrompt(ctx, prompt)
+}
+
 // ProfileCount returns total number of agent profiles.
 func (ps *AgentProfileService) ProfileCount(ctx context.Context) (int64, error) {
 	return ps.svc.Store.ProfileCount(ctx)

--- a/internal/service/agent/agent_provider.go
+++ b/internal/service/agent/agent_provider.go
@@ -22,6 +22,7 @@ type AgentStore interface {
 	GetAgentProfileByBotUserID(botUserID uint64) (*agent.AgentProfile, error)
 	GetAgentProfile(id uint64) (*agent.AgentProfile, error)
 	GetGlobalSystemPrompt() string
+	UpdateGlobalSystemPrompt(ctx context.Context, prompt string) error
 	PostAssistantMessageTx(msg *dm.DmMessage, conv *dm.DmConversation, humanID uint64, now time.Time, preview string) error
 	ResetConversationTx(conv *dm.DmConversation, msg *dm.DmMessage, humanID uint64, now time.Time, preview string) error
 	ReloadConversation(conv *dm.DmConversation) error
@@ -168,6 +169,11 @@ func (s *AgentStoreImpl) GetAgentProfile(id uint64) (*agent.AgentProfile, error)
 // GetGlobalSystemPrompt returns the global agent system prompt.
 func (s *AgentStoreImpl) GetGlobalSystemPrompt() string {
 	return data.GetGlobalSystemPrompt(s.db)
+}
+
+// UpdateGlobalSystemPrompt persists the global (all-role) system prompt.
+func (s *AgentStoreImpl) UpdateGlobalSystemPrompt(ctx context.Context, prompt string) error {
+	return data.UpdateGlobalAgentSettings(s.db.WithContext(ctx), prompt)
 }
 
 // PostAssistantMessageTx persists an assistant message and updates conversation state atomically.


### PR DESCRIPTION
## Summary

Makes the global agent system prompt (the layer applied to ALL agent roles)
editable by admins. Previously it was a hardcoded constant that overwrote the
database on every startup, and neither the admin API nor the admin UI could
change it.

## What changed

- **Seed-if-missing instead of force-sync**: the code constant is now only a
  default for fresh environments. Once the settings row exists, the database is
  the single source of truth — admin edits survive restarts.
- **Admin API**: `GET/PUT /admin/agent-settings` now exposes
  `global_system_prompt`. A PUT containing only `global_system_prompt` updates
  the global layer without touching role fields, so saving the shared prompt
  can never overwrite unsaved role edits.
- **Reliable persistence**: the global prompt is written via an
  `INSERT ... ON CONFLICT(id) DO UPDATE` upsert. This fixes a MySQL-specific
  bug where saving the same value reported 0 affected rows and triggered a
  duplicate primary-key insert (HTTP 500).
- **Admin UI**: the "AI Role Center" page now has a "通用提示词（全局层）"
  editor. It submits only the global field, notes that the change takes effect
  from the next reply, and works alongside per-role persona editing.

## Verification

- `go test -tags=integration ./...` passes (backend coverage ~72%).
- Regression test: saving the same global prompt twice stays a single row with
  no conflict; a restart does not revert an admin-edited prompt.
- Frontend `npm run build` passes; ESLint is clean on the changed page.

## Notes

- The running backend must be rebuilt from this branch to pick up the change.
- Prompt changes take effect from the next LLM reply (read from the DB on each
  generation).