### PR TITLE
feat(worker): explicit transcode DLQ with DB audit and reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ _claude*
 
 # 个人面试准备材料（本地保留，不提交）
 docs/interview-testing.md
+docs/interview-core-chains.md
 # Coverage output file
 coverage
 

--- a/cmd/cakecake/main.go
+++ b/cmd/cakecake/main.go
@@ -193,6 +193,11 @@ func main() {
 		defer wg.Done()
 		worker.StartTranscodeConsumer(ctx, cfg, db, mq, ossc, esc)
 	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.StartTranscodeDeadConsumer(ctx, cfg, db, mq, log)
+	}()
 
 	pc := &playcount.PlayCounter{Rdb: rdb, Store: playcount.NewPlayCountStore(db)}
 	wg.Add(1)

--- a/internal/data/migrate.go
+++ b/internal/data/migrate.go
@@ -114,6 +114,7 @@ func autoMigrateCoreModels(db *gorm.DB, lg *zap.Logger) error {
 		&comment.CommentLike{},
 		&comment.CommentDislike{},
 		&video.VideoLike{},
+		&video.TranscodeDeadLetter{},
 		&video.FavoriteFolder{},
 		&video.VideoFavorite{},
 		&video.VideoCoin{},

--- a/internal/model/video/transcode_dead_letter.go
+++ b/internal/model/video/transcode_dead_letter.go
@@ -1,0 +1,14 @@
+package video
+
+import "time"
+
+// TranscodeDeadLetter records a transcode job whose retries were exhausted.
+// It is the audit/compensation trail behind the RabbitMQ dead-letter queue.
+type TranscodeDeadLetter struct {
+	ID          uint64 `gorm:"primaryKey"`
+	VideoID     uint64 `gorm:"not null;index"`
+	Reason      string `gorm:"size:1900;not null;default:''"`
+	RetryCount  int    `gorm:"type:bigint;not null;default:0"`
+	PayloadJSON string `gorm:"type:text"`
+	CreatedAt   time.Time
+}

--- a/internal/queue/rabbitmq.go
+++ b/internal/queue/rabbitmq.go
@@ -18,6 +18,10 @@ var _ TranscodePublisher = (*Client)(nil)
 // TranscodeQueue is the durable queue name for video transcoding jobs.
 const TranscodeQueue = "mini_bili_transcode"
 
+// TranscodeDeadQueue receives jobs whose retries were exhausted, so failed
+// transcodes are observable and compensable instead of silently dropped.
+const TranscodeDeadQueue = "mini_bili_transcode_dead"
+
 // amqpChannel is the subset of *amqp.Channel needed by Client.
 type amqpChannel interface {
 	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
@@ -51,6 +55,11 @@ func Dial(url string) (*Client, error) {
 		_ = conn.Close()
 		return nil, fmt.Errorf("queue declare: %w", err)
 	}
+	if _, err := ch.QueueDeclare(TranscodeDeadQueue, true, false, false, false, nil); err != nil {
+		_ = ch.Close()
+		_ = conn.Close()
+		return nil, fmt.Errorf("dead queue declare: %w", err)
+	}
 	return &Client{conn: conn, ch: ch}, nil
 }
 
@@ -83,6 +92,14 @@ func (c *Client) ConsumeTranscode(consumerTag string) (<-chan amqp.Delivery, err
 		return nil, fmt.Errorf("channel is nil")
 	}
 	return c.ch.Consume(TranscodeQueue, consumerTag, false, false, false, false, nil)
+}
+
+// ConsumeTranscodeDead registers a consumer for the dead-letter queue.
+func (c *Client) ConsumeTranscodeDead(consumerTag string) (<-chan amqp.Delivery, error) {
+	if c.ch == nil {
+		return nil, fmt.Errorf("channel is nil")
+	}
+	return c.ch.Consume(TranscodeDeadQueue, consumerTag, false, false, false, false, nil)
 }
 
 // NewConsumerChannel opens a dedicated channel for consuming (separate from publish channel).

--- a/internal/worker/transcode.go
+++ b/internal/worker/transcode.go
@@ -245,16 +245,49 @@ func failVideo(db *gorm.DB, id uint64, reason string) {
 }
 
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	r := []rune(s)
+	if len(r) <= n {
 		return s
 	}
-	return s[:n]
+	// Rune-safe: varchar(1900) counts characters, and slicing by bytes could
+	// split a multi-byte UTF-8 sequence (e.g. Chinese in ffmpeg stderr),
+	// producing invalid UTF-8 that MySQL utf8mb4 rejects with Error 1366.
+	return string(r[:n])
+}
+
+// deadLetterTranscode publishes an exhausted job to the dead-letter queue and
+// records it in the DB, so failed transcodes are observable and compensable.
+func deadLetterTranscode(ctx context.Context, db *gorm.DB, pubCh transcodePublisher, lg *zap.Logger, job TranscodeJob, reason string) {
+	if pubCh != nil {
+		body, _ := json.Marshal(job)
+		if err := pubCh.PublishWithContext(ctx, "", queue.TranscodeDeadQueue, false, false, amqp.Publishing{
+			DeliveryMode: amqp.Persistent,
+			ContentType:  "application/json",
+			Body:         body,
+		}); err != nil {
+			lg.Error("publish transcode dead letter", zap.Uint64("video_id", job.VideoID), zap.Error(err))
+		}
+	}
+	if db == nil {
+		return
+	}
+	payload, _ := json.Marshal(map[string]interface{}{"job": job, "reason": reason})
+	rec := video.TranscodeDeadLetter{
+		VideoID:     job.VideoID,
+		Reason:      truncate(reason, 1900),
+		RetryCount:  job.RetryCount,
+		PayloadJSON: string(payload),
+	}
+	if err := db.Create(&rec).Error; err != nil {
+		lg.Warn("record transcode dead letter", zap.Uint64("video_id", job.VideoID), zap.Error(err))
+	}
 }
 
 // requeueOrFail re-enqueues on retryable failure and returns true (caller must preserve RawPath / user cover).
 // On terminal failure returns false, and has already deleted RawPath, CoverPath and local files in terminalLocalExtras.
 func requeueOrFail(ctx context.Context, cfg *config.C, db *gorm.DB, pubCh transcodePublisher, lg *zap.Logger, job TranscodeJob, reason string, terminalLocalExtras ...string) bool {
 	if job.RetryCount >= 3 {
+		deadLetterTranscode(ctx, db, pubCh, lg, job, reason)
 		failVideo(db, job.VideoID, reason)
 		cleanupPaths(append([]string{job.RawPath, job.CoverPath}, terminalLocalExtras...)...)
 		lg.Error("transcode exhausted retries", zap.Uint64("video_id", job.VideoID))
@@ -271,9 +304,63 @@ func requeueOrFail(ctx context.Context, cfg *config.C, db *gorm.DB, pubCh transc
 		Body:         body,
 	}); err != nil {
 		lg.Error("republish transcode job", zap.Error(err))
+		deadLetterTranscode(ctx, db, pubCh, lg, job, reason)
 		failVideo(db, job.VideoID, reason)
 		cleanupPaths(append([]string{job.RawPath, job.CoverPath}, terminalLocalExtras...)...)
 		return false
 	}
 	return true
+}
+
+// StartTranscodeDeadConsumer drains the dead-letter queue, logging each
+// exhausted job. The DB record is the durable audit/compensation trail.
+func StartTranscodeDeadConsumer(ctx context.Context, cfg *config.C, db *gorm.DB, mq *queue.Client, lg *zap.Logger) {
+	if mq == nil {
+		return
+	}
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		ch, err := mq.NewConsumerChannel()
+		if err != nil {
+			lg.Warn("transcode dead consumer: open channel", zap.Error(err))
+		} else {
+			msgs, cerr := ch.Consume(queue.TranscodeDeadQueue, "transcode-dead-worker", false, false, false, false, nil)
+			if cerr != nil {
+				lg.Warn("transcode dead consumer: subscribe", zap.Error(cerr))
+				_ = ch.Close()
+			} else {
+				consumeTranscodeDead(ctx, ch, msgs, lg)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// consumeTranscodeDead drains one dead-letter channel. It returns when the
+// channel closes or the context is cancelled; the caller reconnects.
+func consumeTranscodeDead(ctx context.Context, ch *amqp.Channel, msgs <-chan amqp.Delivery, lg *zap.Logger) {
+	defer ch.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case d, ok := <-msgs:
+			if !ok {
+				return
+			}
+			var job TranscodeJob
+			_ = json.Unmarshal(d.Body, &job)
+			lg.Warn("transcode dead letter consumed",
+				zap.Uint64("video_id", job.VideoID),
+				zap.Int("retry_count", job.RetryCount),
+			)
+			_ = d.Ack(false)
+		}
+	}
 }

--- a/internal/worker/transcode_pipeline_test.go
+++ b/internal/worker/transcode_pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	amqp "github.com/rabbitmq/amqp091-go"
@@ -15,6 +16,7 @@ import (
 	"gorm.io/gorm"
 
 	"cakecake/internal/config"
+	"cakecake/internal/model/video"
 	"cakecake/internal/queue"
 )
 
@@ -60,11 +62,13 @@ func (f *fakeFFmpeg) IsPermanentTranscodeFailure(stderr string) bool {
 
 type fakePublisher struct {
 	published []amqp.Publishing
+	keys      []string
 	err       error
 }
 
 func (f *fakePublisher) PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error {
 	f.published = append(f.published, msg)
+	f.keys = append(f.keys, key)
 	return f.err
 }
 
@@ -150,6 +154,8 @@ func TestHandleDelivery_TranscodePermanent(t *testing.T) {
 
 func TestHandleDelivery_TranscodeRetryableExhausted(t *testing.T) {
 	db, mock := newMockDB(t)
+	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	ack := &fakeAck{}
@@ -161,9 +167,8 @@ func TestHandleDelivery_TranscodeRetryableExhausted(t *testing.T) {
 	if ack.acked != 1 {
 		t.Errorf("expected 1 ack, got %d", ack.acked)
 	}
-	if len(pub.published) != 0 {
-		t.Errorf("expected no republish on exhausted retries")
-	}
+	require.Len(t, pub.published, 1)
+	require.Equal(t, queue.TranscodeDeadQueue, pub.keys[0])
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -183,6 +188,7 @@ func TestHandleDelivery_TranscodeRetryableRepublish(t *testing.T) {
 		t.Errorf("expected 1 ack, got %d", ack.acked)
 	}
 	require.Len(t, pub.published, 1)
+	require.Equal(t, queue.TranscodeQueue, pub.keys[0])
 	var republished queue.TranscodeJob
 	require.NoError(t, json.Unmarshal(pub.published[0].Body, &republished))
 	if republished.RetryCount != 1 {
@@ -193,6 +199,8 @@ func TestHandleDelivery_TranscodeRetryableRepublish(t *testing.T) {
 
 func TestHandleDelivery_RepublishFailure(t *testing.T) {
 	db, mock := newMockDB(t)
+	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	oldDelay := transcodeRetryBaseDelay
@@ -213,6 +221,8 @@ func TestHandleDelivery_RepublishFailure(t *testing.T) {
 
 func TestHandleDelivery_UploadVideoFailsExhausted(t *testing.T) {
 	db, mock := newMockDB(t)
+	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	ack := &fakeAck{}
@@ -225,6 +235,40 @@ func TestHandleDelivery_UploadVideoFailsExhausted(t *testing.T) {
 		t.Errorf("expected 1 ack, got %d", ack.acked)
 	}
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDeadLetterTranscode_PersistsAndPublishes(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	pub := &fakePublisher{}
+	job := queue.TranscodeJob{VideoID: 7, RawPath: "/tmp/r.mp4", RetryCount: 3}
+	deadLetterTranscode(context.Background(), db, pub, zap.NewNop(), job, "oss down")
+
+	require.Len(t, pub.published, 1)
+	require.Equal(t, queue.TranscodeDeadQueue, pub.keys[0])
+	var dead queue.TranscodeJob
+	require.NoError(t, json.Unmarshal(pub.published[0].Body, &dead))
+	require.Equal(t, uint64(7), dead.VideoID)
+
+	var rec video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 7).First(&rec).Error)
+	require.Equal(t, "oss down", rec.Reason)
+	require.Equal(t, 3, rec.RetryCount)
+	require.Contains(t, rec.PayloadJSON, "oss down")
+}
+
+func TestTruncate_RuneSafeUTF8(t *testing.T) {
+	// Byte slicing could split multi-byte UTF-8 runes; truncation must stay
+	// valid UTF-8 and never exceed the rune budget.
+	reason := "ffmpeg 转码失败: 文件损坏"
+	for n := 1; n <= len(reason); n++ {
+		got := truncate(reason, n)
+		require.True(t, utf8.ValidString(got), "truncate(%q, %d) produced invalid UTF-8", reason, n)
+		require.LessOrEqual(t, utf8.RuneCountInString(got), n)
+	}
+	require.Equal(t, "ffmpeg ", truncate(reason, 7))
+	require.Equal(t, "abc", truncate("abcdef", 3))
+	require.Equal(t, "abcdef", truncate("abcdef", 6))
+	require.Equal(t, "", truncate("abc", 0))
 }
 
 func TestHandleDelivery_SuccessDBError(t *testing.T) {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -19,8 +19,9 @@ func TestTruncate(t *testing.T) {
 		{"", 5, ""},
 		{"abc", 0, ""},
 		{"hello world", 5, "hello"},
-		// truncate works on bytes, not runes
-		{"你好世界", 6, "你好"}, // each Chinese char = 3 bytes, 6 bytes = 2 chars
+		// truncate counts runes, so it never splits multi-byte UTF-8
+		{"你好世界", 2, "你好"},
+		{"你好世界", 3, "你好世"},
 		{"abcdef", 6, "abcdef"},
 	}
 	for _, tc := range tests {

--- a/migrations/00005_transcode_dead_letters.sql
+++ b/migrations/00005_transcode_dead_letters.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS `transcode_dead_letters` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `video_id` bigint unsigned NOT NULL,
+  `reason` varchar(1900) NOT NULL DEFAULT '',
+  `retry_count` bigint NOT NULL DEFAULT 0,
+  `payload_json` text,
+  `created_at` datetime(3) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_transcode_dead_letters_video_id` (`video_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- +goose Down
+DROP TABLE IF EXISTS `transcode_dead_letters`;

--- a/scripts/check_en_sync.py
+++ b/scripts/check_en_sync.py
@@ -24,6 +24,7 @@ SKIP_PATTERNS = [
     "ci-checks*.md",
     # 个人面试准备材料，不要求英文对照，也不提交仓库
     "interview-testing*.md",
+    "interview-core-chains*.md",
 ]
 
 def extract_heading_levels(text):


### PR DESCRIPTION
## Summary

Adds an explicit dead-letter queue for exhausted transcode retries, plus review fixes.

### Dead-letter queue (DLQ)
- New durable queue `mini_bili_transcode_dead`, declared at dial time and consumed via `ConsumeTranscodeDead`.
- When retries are exhausted (`RetryCount >= 3`) or republish fails, the job is published to the DLQ and recorded in a new `transcode_dead_letters` table (video_id, reason, retry_count, payload_json) before the video is marked failed and the message is acked.
- New `StartTranscodeDeadConsumer` drains the DLQ, logs each dead letter, and acks; the DB table is the durable audit/compensation trail.
- New model `TranscodeDeadLetter` + goose migration `00005_transcode_dead_letters`.

### Review fixes
- `truncate` is now rune-safe: byte slicing could split multi-byte UTF-8 (e.g. Chinese in ffmpeg stderr) and fail MySQL utf8mb4 with Error 1366.
- `TranscodeDeadLetter.RetryCount` is explicitly tagged `type:bigint` to match the goose migration (GORM already maps Go `int` to `bigint` on MySQL).
- The dead-letter consumer reconnects with a 3s backoff after channel loss; the main consumer keeps its fail-fast design.

### Verification
- New `TestDeadLetterTranscode_PersistsAndPublishes` and rune-safe truncation tests pass.
- Full `go test -tags=integration ./...` green across 52 packages.
- go vet / golangci-lint / dependency-direction checks pass.