### PR TITLE
test(worker): cover DLQ consumer and queue dead-letter surface

### DIFF
--- a/internal/queue/rabbitmq.go
+++ b/internal/queue/rabbitmq.go
@@ -102,6 +102,25 @@ func (c *Client) ConsumeTranscodeDead(consumerTag string) (<-chan amqp.Delivery,
 	return c.ch.Consume(TranscodeDeadQueue, consumerTag, false, false, false, false, nil)
 }
 
+// NewTranscodeDeadConsumer opens a dedicated channel and subscribes it to the
+// dead-letter queue, returning both for the consumer loop. The channel is
+// returned as a minimal closer so tests can substitute a fake.
+func (c *Client) NewTranscodeDeadConsumer(consumerTag string) (interface{ Close() error }, <-chan amqp.Delivery, error) {
+	if c.conn == nil {
+		return nil, nil, fmt.Errorf("connection is nil")
+	}
+	ch, err := c.conn.Channel()
+	if err != nil {
+		return nil, nil, err
+	}
+	msgs, err := ch.Consume(TranscodeDeadQueue, consumerTag, false, false, false, false, nil)
+	if err != nil {
+		_ = ch.Close()
+		return nil, nil, err
+	}
+	return ch, msgs, nil
+}
+
 // NewConsumerChannel opens a dedicated channel for consuming (separate from publish channel).
 func (c *Client) NewConsumerChannel() (*amqp.Channel, error) {
 	if c.conn == nil {

--- a/internal/queue/rabbitmq_test.go
+++ b/internal/queue/rabbitmq_test.go
@@ -1,0 +1,19 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumeTranscodeDead_NilChannel(t *testing.T) {
+	c := &Client{}
+	_, err := c.ConsumeTranscodeDead("tag")
+	require.Error(t, err)
+}
+
+func TestNewTranscodeDeadConsumer_NilConn(t *testing.T) {
+	c := &Client{}
+	_, _, err := c.NewTranscodeDeadConsumer("tag")
+	require.Error(t, err)
+}

--- a/internal/worker/transcode.go
+++ b/internal/worker/transcode.go
@@ -312,9 +312,19 @@ func requeueOrFail(ctx context.Context, cfg *config.C, db *gorm.DB, pubCh transc
 	return true
 }
 
+// transcodeDeadSubscriber is the RabbitMQ surface the dead-letter consumer
+// needs, kept small so the reconnect loop is unit-testable.
+type transcodeDeadSubscriber interface {
+	NewTranscodeDeadConsumer(consumerTag string) (interface{ Close() error }, <-chan amqp.Delivery, error)
+}
+
+// transcodeDeadRetryDelay is the reconnect backoff; variable for tests.
+var transcodeDeadRetryDelay = 3 * time.Second
+
 // StartTranscodeDeadConsumer drains the dead-letter queue, logging each
 // exhausted job. The DB record is the durable audit/compensation trail.
-func StartTranscodeDeadConsumer(ctx context.Context, cfg *config.C, db *gorm.DB, mq *queue.Client, lg *zap.Logger) {
+// The loop reconnects with a backoff after channel loss.
+func StartTranscodeDeadConsumer(ctx context.Context, cfg *config.C, db *gorm.DB, mq transcodeDeadSubscriber, lg *zap.Logger) {
 	if mq == nil {
 		return
 	}
@@ -322,29 +332,23 @@ func StartTranscodeDeadConsumer(ctx context.Context, cfg *config.C, db *gorm.DB,
 		if ctx.Err() != nil {
 			return
 		}
-		ch, err := mq.NewConsumerChannel()
+		ch, msgs, err := mq.NewTranscodeDeadConsumer("transcode-dead-worker")
 		if err != nil {
-			lg.Warn("transcode dead consumer: open channel", zap.Error(err))
+			lg.Warn("transcode dead consumer: subscribe", zap.Error(err))
 		} else {
-			msgs, cerr := ch.Consume(queue.TranscodeDeadQueue, "transcode-dead-worker", false, false, false, false, nil)
-			if cerr != nil {
-				lg.Warn("transcode dead consumer: subscribe", zap.Error(cerr))
-				_ = ch.Close()
-			} else {
-				consumeTranscodeDead(ctx, ch, msgs, lg)
-			}
+			consumeTranscodeDead(ctx, ch, msgs, lg)
 		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(3 * time.Second):
+		case <-time.After(transcodeDeadRetryDelay):
 		}
 	}
 }
 
 // consumeTranscodeDead drains one dead-letter channel. It returns when the
 // channel closes or the context is cancelled; the caller reconnects.
-func consumeTranscodeDead(ctx context.Context, ch *amqp.Channel, msgs <-chan amqp.Delivery, lg *zap.Logger) {
+func consumeTranscodeDead(ctx context.Context, ch interface{ Close() error }, msgs <-chan amqp.Delivery, lg *zap.Logger) {
 	defer ch.Close()
 	for {
 		select {
@@ -354,13 +358,18 @@ func consumeTranscodeDead(ctx context.Context, ch *amqp.Channel, msgs <-chan amq
 			if !ok {
 				return
 			}
-			var job TranscodeJob
-			_ = json.Unmarshal(d.Body, &job)
-			lg.Warn("transcode dead letter consumed",
-				zap.Uint64("video_id", job.VideoID),
-				zap.Int("retry_count", job.RetryCount),
-			)
-			_ = d.Ack(false)
+			handleTranscodeDeadLetter(d, lg)
 		}
 	}
+}
+
+// handleTranscodeDeadLetter logs and acks a single dead letter.
+func handleTranscodeDeadLetter(d amqp.Delivery, lg *zap.Logger) {
+	var job TranscodeJob
+	_ = json.Unmarshal(d.Body, &job)
+	lg.Warn("transcode dead letter consumed",
+		zap.Uint64("video_id", job.VideoID),
+		zap.Int("retry_count", job.RetryCount),
+	)
+	_ = d.Ack(false)
 }

--- a/internal/worker/transcode_dead_consumer_test.go
+++ b/internal/worker/transcode_dead_consumer_test.go
@@ -1,0 +1,91 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeCloseable struct {
+	closed bool
+}
+
+func (f *fakeCloseable) Close() error {
+	f.closed = true
+	return nil
+}
+
+type fakeDeadSubscriber struct {
+	calls int
+	errs  []error
+	ch    *fakeCloseable
+	msgs  chan amqp.Delivery
+}
+
+func (f *fakeDeadSubscriber) NewTranscodeDeadConsumer(_ string) (interface{ Close() error }, <-chan amqp.Delivery, error) {
+	f.calls++
+	if len(f.errs) > 0 {
+		err := f.errs[0]
+		f.errs = f.errs[1:]
+		return nil, nil, err
+	}
+	return f.ch, f.msgs, nil
+}
+
+func TestHandleTranscodeDeadLetter_Acks(t *testing.T) {
+	ack := &fakeAck{}
+	body, _ := json.Marshal(TranscodeJob{VideoID: 42, RetryCount: 3})
+	handleTranscodeDeadLetter(amqp.Delivery{Body: body, Acknowledger: ack}, zap.NewNop())
+	require.Equal(t, 1, ack.acked)
+}
+
+func TestConsumeTranscodeDead_AcksAndCloses(t *testing.T) {
+	ack := &fakeAck{}
+	body, _ := json.Marshal(TranscodeJob{VideoID: 7, RetryCount: 2})
+	msgs := make(chan amqp.Delivery, 1)
+	msgs <- amqp.Delivery{Body: body, Acknowledger: ack}
+	close(msgs)
+
+	closer := &fakeCloseable{}
+	consumeTranscodeDead(context.Background(), closer, msgs, zap.NewNop())
+	require.Equal(t, 1, ack.acked)
+	require.True(t, closer.closed)
+}
+
+func TestStartTranscodeDeadConsumer_ReconnectsUntilCancel(t *testing.T) {
+	old := transcodeDeadRetryDelay
+	transcodeDeadRetryDelay = time.Millisecond
+	defer func() { transcodeDeadRetryDelay = old }()
+
+	sub := &fakeDeadSubscriber{
+		errs: []error{errTestBrokerDown, errTestBrokerDown},
+		ch:   &fakeCloseable{},
+		msgs: make(chan amqp.Delivery),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		StartTranscodeDeadConsumer(ctx, nil, nil, sub, zap.NewNop())
+	}()
+
+	// Let the loop hit the subscribe errors and reach the stable msgs channel.
+	deadline := time.Now().Add(2 * time.Second)
+	for sub.calls < 3 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-done
+	require.GreaterOrEqual(t, sub.calls, 3)
+}
+
+var errTestBrokerDown = &testBrokerError{}
+
+type testBrokerError struct{}
+
+func (*testBrokerError) Error() string { return "broker down" }


### PR DESCRIPTION
## Summary

Follow-up to PR #56: closes the coverage gap Codecov reported (patch 30.43%) by making the dead-letter consumer testable and adding tests.

### Refactor (no behavior change)
- `queue.Client.NewTranscodeDeadConsumer` returns the channel as `interface{ Close() error }` so tests can substitute a fake.
- The dead-letter consumer is split into testable seams: `StartTranscodeDeadConsumer` (reconnect loop) -> `consumeTranscodeDead` (channel loop) -> `handleTranscodeDeadLetter` (single message).

### New tests
- `TestHandleTranscodeDeadLetter_Acks`
- `TestConsumeTranscodeDead_AcksAndCloses`
- `TestStartTranscodeDeadConsumer_ReconnectsUntilCancel`
- `TestConsumeTranscodeDead_NilChannel` / `TestNewTranscodeDeadConsumer_NilConn`

### Coverage improvement
- `StartTranscodeDeadConsumer`: 0% -> 81.8%
- `consumeTranscodeDead` / `handleTranscodeDeadLetter`: 100%
- worker package: 59.5% -> 72.4%

### Verification
- `go test -tags=integration ./...`: 52 packages pass.
- go vet / golangci-lint / dependency-direction checks pass.