### PR TITLE
feat(worker): transcode DLQ requeue, retention, admin UI and alerting

### DIFF
--- a/cakecake-vue/cakecake-web/src/api/admin.js
+++ b/cakecake-vue/cakecake-web/src/api/admin.js
@@ -180,6 +180,16 @@ export function adminDeleteAgentProfile(id) {
   return adminHttp.delete(`/api/v1/admin/agent-profiles/${id}`);
 }
 
+export function adminListTranscodeDeadLetters(params) {
+  return adminHttp.get("/api/v1/admin/transcode-dead-letters", { params });
+}
+
+export function adminRequeueTranscodeDeadLetter(id) {
+  return adminHttp.post(`/api/v1/admin/transcode-dead-letters/${id}/requeue`, null, {
+    skipGlobalErrorToast: true
+  });
+}
+
 export function adminUploadAgentProfileAvatar(id, file) {
   const fd = new FormData();
   fd.append("image", file);

--- a/cakecake-vue/cakecake-web/src/pages/admin/AdminLayout.vue
+++ b/cakecake-vue/cakecake-web/src/pages/admin/AdminLayout.vue
@@ -70,6 +70,13 @@
         >
           运行时配置
         </router-link>
+        <router-link
+          :to="{ name: 'adminTranscodeDeadLetters' }"
+          class="adm-side__item"
+          active-class="adm-side__item--on"
+        >
+          转码死信
+        </router-link>
       </aside>
       <main class="adm-main">
         <router-view />

--- a/cakecake-vue/cakecake-web/src/pages/admin/TranscodeDeadLetterManage.vue
+++ b/cakecake-vue/cakecake-web/src/pages/admin/TranscodeDeadLetterManage.vue
@@ -1,0 +1,173 @@
+<template>
+  <div class="tdl-manage">
+    <header class="tdl-manage__head">
+      <div>
+        <h2>转码死信</h2>
+        <p>转码重试耗尽的任务会进入死信队列并记录于此；可按状态筛选并重新入队。</p>
+      </div>
+      <div class="tdl-manage__actions">
+        <el-select
+          v-model="status"
+          class="tdl-manage__status"
+          placeholder="全部状态"
+          @change="reload"
+        >
+          <el-option label="全部" value="" />
+          <el-option label="待处理" value="pending" />
+          <el-option label="已重放" value="requeued" />
+          <el-option label="已处理" value="processed" />
+        </el-select>
+        <el-button :loading="loading" @click="reload">刷新</el-button>
+      </div>
+    </header>
+
+    <el-table :data="items" v-loading="loading" border stripe>
+      <el-table-column prop="id" label="ID" width="80" />
+      <el-table-column prop="video_id" label="视频ID" width="90" />
+      <el-table-column prop="reason" label="失败原因" min-width="220" show-overflow-tooltip />
+      <el-table-column prop="retry_count" label="重试次数" width="90" />
+      <el-table-column label="状态" width="100">
+        <template #default="{ row }">
+          <el-tag :type="statusType(row)" size="small">{{ statusLabel(row) }}</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column label="创建时间" width="170">
+        <template #default="{ row }">{{ formatTime(row.created_at) }}</template>
+      </el-table-column>
+      <el-table-column prop="requeued_count" label="重放次数" width="90" />
+      <el-table-column label="操作" width="120" fixed="right">
+        <template #default="{ row }">
+          <el-button
+            type="primary"
+            size="small"
+            :loading="requeuingId === row.id"
+            :disabled="requeuingId !== null && requeuingId !== row.id"
+            @click="requeue(row)"
+          >
+            重新入队
+          </el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-pagination
+      class="tdl-manage__pager"
+      layout="total, prev, pager, next"
+      :total="total"
+      :page-size="pageSize"
+      :current-page="page"
+      @current-change="changePage"
+    />
+  </div>
+</template>
+
+<script>
+import { ElMessage, ElMessageBox } from "element-plus";
+import {
+  adminListTranscodeDeadLetters,
+  adminRequeueTranscodeDeadLetter
+} from "@/api/admin";
+
+export default {
+  name: "TranscodeDeadLetterManage",
+  data() {
+    return {
+      loading: false,
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+      status: "",
+      requeuingId: null
+    };
+  },
+  created() {
+    this.reload();
+  },
+  methods: {
+    async reload() {
+      this.loading = true;
+      try {
+        const r = await adminListTranscodeDeadLetters({
+          page: this.page,
+          page_size: this.pageSize,
+          status: this.status
+        });
+        this.items = r.data.items || [];
+        this.total = r.data.total || 0;
+      } catch {
+        ElMessage.error("加载转码死信失败");
+      } finally {
+        this.loading = false;
+      }
+    },
+    changePage(p) {
+      this.page = p;
+      this.reload();
+    },
+    statusLabel(row) {
+      if (row.requeued_at) return "已重放";
+      if (row.processed_at) return "已处理";
+      return "待处理";
+    },
+    statusType(row) {
+      if (row.requeued_at) return "warning";
+      if (row.processed_at) return "info";
+      return "danger";
+    },
+    formatTime(t) {
+      return t ? String(t).replace("T", " ").slice(0, 19) : "—";
+    },
+    async requeue(row) {
+      try {
+        await ElMessageBox.confirm(
+          `确定将死信 #${row.id}（视频 ${row.video_id}）重新入队吗？视频将回到处理中状态。`,
+          "重新入队",
+          { type: "warning" }
+        );
+      } catch {
+        return;
+      }
+      this.requeuingId = row.id;
+      try {
+        await adminRequeueTranscodeDeadLetter(row.id);
+        ElMessage.success("已重新入队");
+        await this.reload();
+      } catch (e) {
+        ElMessage.error(e?.response?.data?.msg || "重新入队失败");
+      } finally {
+        this.requeuingId = null;
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.tdl-manage__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.tdl-manage__head h2 {
+  margin: 0 0 4px;
+}
+.tdl-manage__head p {
+  margin: 0;
+  color: #888;
+  font-size: 13px;
+}
+.tdl-manage__actions {
+  display: flex;
+  gap: 8px;
+}
+.tdl-manage__status {
+  width: 140px;
+}
+.tdl-manage__pager {
+  margin-top: 16px;
+  justify-content: flex-end;
+}
+</style>

--- a/cakecake-vue/cakecake-web/src/router/index.js
+++ b/cakecake-vue/cakecake-web/src/router/index.js
@@ -315,6 +315,12 @@ const routes = [
         name: "adminSystemConfigs",
         component: () => import("@/pages/admin/SystemConfigManage.vue"),
         meta: { title: "运行时配置 - 运营后台" }
+      },
+      {
+        path: "transcode-dead-letters",
+        name: "adminTranscodeDeadLetters",
+        component: () => import("@/pages/admin/TranscodeDeadLetterManage.vue"),
+        meta: { title: "转码死信 - 运营后台" }
       }
     ]
   },

--- a/cmd/cakecake/main.go
+++ b/cmd/cakecake/main.go
@@ -198,6 +198,11 @@ func main() {
 		defer wg.Done()
 		worker.StartTranscodeDeadConsumer(ctx, cfg, db, mq, log)
 	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.StartTranscodeDeadRetention(ctx, db, log)
+	}()
 
 	pc := &playcount.PlayCounter{Rdb: rdb, Store: playcount.NewPlayCountStore(db)}
 	wg.Add(1)

--- a/deploy/monitoring/grafana/dashboards/cakecake-transcode.json
+++ b/deploy/monitoring/grafana/dashboards/cakecake-transcode.json
@@ -1,0 +1,146 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 1,
+  "id": null,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Transcode Dead Letters /s",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "targets": [
+        {
+          "expr": "sum(rate(cakecake_transcode_dead_letters_total{instance=~\"$instance\"}[5m])) by (instance)",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Transcode Dead Letters Requeued /s",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2, "showPoints": "never"},
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "targets": [
+        {
+          "expr": "sum(rate(cakecake_transcode_requeued_total{instance=~\"$instance\"}[5m])) by (instance)",
+          "interval": "15s",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Transcode Dead Letters (24h total)",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1, "showPoints": "never"},
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "targets": [
+        {
+          "expr": "sum(increase(cakecake_transcode_dead_letters_total{instance=~\"$instance\"}[24h])) by (instance)",
+          "interval": "1m",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Transcode Dead Letters Requeued (24h total)",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1, "showPoints": "never"},
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "targets": [
+        {
+          "expr": "sum(increase(cakecake_transcode_requeued_total{instance=~\"$instance\"}[24h])) by (instance)",
+          "interval": "1m",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["cakecake", "transcode"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": true, "text": ["All"], "value": ["$__all"]},
+        "definition": "label_values(up{job=~\"cakecake-backend.*\"}, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {"query": "label_values(up{job=~\"cakecake-backend.*\"}, instance)", "refId": "StandardVariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "CakeCake Transcode",
+  "uid": "cakecake-transcode",
+  "version": 1
+}

--- a/deploy/monitoring/rules/cakecake-transcode.yml
+++ b/deploy/monitoring/rules/cakecake-transcode.yml
@@ -1,0 +1,19 @@
+groups:
+  - name: cakecake-transcode
+    rules:
+      - alert: CakecakeTranscodeDeadLetters
+        expr: increase(cakecake_transcode_dead_letters_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Transcode dead letters detected"
+          description: "Transcode jobs were dead-lettered in the last 5 minutes. Check transcode_dead_letters and the admin API."
+      - alert: CakecakeTranscodeRequeued
+        expr: increase(cakecake_transcode_requeued_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: info
+        annotations:
+          summary: "Transcode dead letters requeued"
+          description: "Transcode dead letters were requeued via the admin API in the last 5 minutes."

--- a/internal/client/VideoSvc.go
+++ b/internal/client/VideoSvc.go
@@ -29,8 +29,10 @@ type VideoSvc interface {
 	ListMyVideosAdvanced(ctx context.Context, f servicevideo.MyVideoFilter) (*servicevideo.MyVideoPageResult, error)
 	ListPublishedVideos(ctx context.Context, opts servicevideo.VideoListOpts) (*servicevideo.VideoListResult, error)
 	ListUserPublishedVideosCursor(ctx context.Context, uid uint64, cursorID uint64, limit int) ([]video.Video, error)
+	ListTranscodeDeadLetters(ctx context.Context, f servicevideo.TranscodeDeadLetterFilter) ([]video.TranscodeDeadLetter, int64, error)
 	ProbeDurationSeconds(path string) (float64, error)
 	Publish(ctx context.Context, videoID uint64, adminID *uint64) error
+	RequeueTranscodeDeadLetter(ctx context.Context, id uint64) error
 	ToggleVideoLike(ctx context.Context, userID uint64, videoID uint64) (bool, error)
 	UpdateVideo(ctx context.Context, v *video.Video, updates map[string]interface{}) error
 }

--- a/internal/data/data_advanced_test.go
+++ b/internal/data/data_advanced_test.go
@@ -6,6 +6,7 @@ import (
 	"cakecake/internal/model/comment"
 	"cakecake/internal/model/danmaku"
 	"cakecake/internal/model/notification"
+	"cakecake/internal/model/system"
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
 	"errors"
@@ -43,6 +44,30 @@ func TestAutoMigrateAll(t *testing.T) {
 	assert.True(t, db.Migrator().HasTable(&user.UserFollow{}))
 	assert.True(t, db.Migrator().HasTable(&notification.Notification{}))
 	assert.True(t, db.Migrator().HasTable(&admin.HomeBanner{}))
+	assert.True(t, db.Migrator().HasTable(&video.TranscodeDeadLetter{}))
+	assert.True(t, db.Migrator().HasColumn(&video.TranscodeDeadLetter{}, "processed_at"))
+	assert.True(t, db.Migrator().HasColumn(&video.TranscodeDeadLetter{}, "requeued_at"))
+	assert.True(t, db.Migrator().HasColumn(&video.TranscodeDeadLetter{}, "requeued_count"))
+}
+
+// TestAutoMigrateAll_RecreatesMissingTranscodeDeadLetters simulates an
+// existing database whose v1 core_schema migration was recorded before the
+// TranscodeDeadLetter model existed: v1 is skipped on the next run, so the
+// table must be created by its own versioned migration (v23).
+func TestAutoMigrateAll_RecreatesMissingTranscodeDeadLetters(t *testing.T) {
+	db := setupDataDB(t)
+	require.NoError(t, AutoMigrateAll(db, zap.NewNop()))
+	require.True(t, db.Migrator().HasTable(&video.TranscodeDeadLetter{}))
+
+	// Simulate the pre-DLQ installation: table missing, schema_versions
+	// already records v1..v22 (v23 is what this test must re-run).
+	require.NoError(t, db.Migrator().DropTable(&video.TranscodeDeadLetter{}))
+	require.False(t, db.Migrator().HasTable(&video.TranscodeDeadLetter{}))
+	require.NoError(t, db.Where("version = ?", 23).Delete(&system.SchemaVersion{}).Error)
+
+	require.NoError(t, AutoMigrateAll(db, zap.NewNop()))
+	require.True(t, db.Migrator().HasTable(&video.TranscodeDeadLetter{}))
+	require.True(t, db.Migrator().HasColumn(&video.TranscodeDeadLetter{}, "requeued_count"))
 }
 
 func TestAutoMigrateAll_Idempotent(t *testing.T) {

--- a/internal/data/migrate.go
+++ b/internal/data/migrate.go
@@ -50,7 +50,22 @@ func RegisteredMigrations() []Migration {
 		{20, "dm_message_content_text", "enlarge dm_messages.content to TEXT for long AI replies", migrateDmMessageContentText},
 		{21, "dm_message_suggestions", "add suggestions column for AI follow-up chips", migrateDmMessageSuggestions},
 		{22, "agent_feedback_table", "create agent_feedbacks table", migrateAgentFeedbackTable},
+		{23, "transcode_dead_letters", "create transcode_dead_letters audit table", migrateTranscodeDeadLetters},
 	}
+}
+
+// migrateTranscodeDeadLetters creates the transcode_dead_letters audit table
+// (including lifecycle columns) for installations whose v1 core_schema
+// migration predates the model. Existing fresh databases get the table from
+// autoMigrateCoreModels, so this is a no-op for them.
+func migrateTranscodeDeadLetters(db *gorm.DB, lg *zap.Logger) error {
+	if err := db.AutoMigrate(&video.TranscodeDeadLetter{}); err != nil {
+		return err
+	}
+	if lg != nil {
+		lg.Info("created transcode_dead_letters table")
+	}
+	return nil
 }
 
 // migrateAgentFeedbackTable creates agent_feedbacks for existing installations.

--- a/internal/errcode/errcode.go
+++ b/internal/errcode/errcode.go
@@ -25,6 +25,7 @@ const (
 	CodeInsufficientCoins     = 40020
 	CodeCommentSensitive      = 40021
 	CodeVideoUploadDisabled   = 40022
+	CodeRequeueSourceMissing  = 40023
 	CodeTooManyRequests       = 42900
 	CodeUnauthorized          = 40100
 	CodeInvalidLogin          = 40101
@@ -61,6 +62,7 @@ var messages = map[int]string{
 	CodeInsufficientCoins:     "硬币不足",
 	CodeCommentSensitive:      "评论内容包含违规信息",
 	CodeVideoUploadDisabled:   "云端视频上传已关闭，可先保存稿件信息；视频文件将由管理员线下处理",
+	CodeRequeueSourceMissing:  "原始文件已被清理，无法重新入队；请让用户重新上传视频",
 	CodeTooManyRequests:       "请求过于频繁，请稍后重试",
 	CodeDanmakuCooldown:       "发送过于频繁，请稍后再试",
 	CodeDanmakuSensitive:      "弹幕内容包含违规信息",

--- a/internal/handler/admin_transcode_dead_letter.go
+++ b/internal/handler/admin_transcode_dead_letter.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"cakecake/internal/errcode"
+	"cakecake/internal/middleware"
+	"cakecake/internal/model/video"
+	"cakecake/internal/pkg/resp"
+	vsvc "cakecake/internal/service/video"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+type transcodeDeadLetterItem struct {
+	ID            uint64  `json:"id"`
+	VideoID       uint64  `json:"video_id"`
+	Reason        string  `json:"reason"`
+	RetryCount    int     `json:"retry_count"`
+	PayloadJSON   string  `json:"payload_json"`
+	CreatedAt     string  `json:"created_at"`
+	ProcessedAt   *string `json:"processed_at"`
+	RequeuedAt    *string `json:"requeued_at"`
+	RequeuedCount int     `json:"requeued_count"`
+}
+
+func fmtTimePtr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
+}
+
+func deadLetterItemFromRow(r *video.TranscodeDeadLetter) transcodeDeadLetterItem {
+	return transcodeDeadLetterItem{
+		ID:            r.ID,
+		VideoID:       r.VideoID,
+		Reason:        r.Reason,
+		RetryCount:    r.RetryCount,
+		PayloadJSON:   r.PayloadJSON,
+		CreatedAt:     r.CreatedAt.Format(time.RFC3339),
+		ProcessedAt:   fmtTimePtr(r.ProcessedAt),
+		RequeuedAt:    fmtTimePtr(r.RequeuedAt),
+		RequeuedCount: r.RequeuedCount,
+	}
+}
+
+// AdminListTranscodeDeadLetters lists dead-letter audit rows.
+func (a *API) AdminListTranscodeDeadLetters(c *gin.Context) {
+	page, pageSize := parsePagination(c, 20)
+	f := vsvc.TranscodeDeadLetterFilter{
+		Page:     page,
+		PageSize: pageSize,
+		Status:   c.Query("status"),
+	}
+	rows, total, err := a.VideoSvc.ListTranscodeDeadLetters(c.Request.Context(), f)
+	if err != nil {
+		a.Log.Error("list transcode dead letters", zap.Error(err))
+		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
+		return
+	}
+	items := make([]transcodeDeadLetterItem, 0, len(rows))
+	for i := range rows {
+		items = append(items, deadLetterItemFromRow(&rows[i]))
+	}
+	totalPages := 0
+	if pageSize > 0 {
+		totalPages = int((total + int64(pageSize) - 1) / int64(pageSize))
+	}
+	resp.OK(c, gin.H{
+		"items":       items,
+		"page":        page,
+		"page_size":   pageSize,
+		"total":       total,
+		"total_pages": totalPages,
+	})
+}
+
+// AdminRequeueTranscodeDeadLetter re-publishes a dead letter to the main queue.
+func (a *API) AdminRequeueTranscodeDeadLetter(c *gin.Context) {
+	if _, ok := middleware.AdminID(c); !ok {
+		resp.Err(c, http.StatusUnauthorized, errcode.CodeUnauthorized)
+		return
+	}
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
+		return
+	}
+	if err := a.VideoSvc.RequeueTranscodeDeadLetter(c.Request.Context(), id); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
+			return
+		}
+		if errors.Is(err, vsvc.ErrRequeueSourceMissing) {
+			resp.Err(c, http.StatusConflict, errcode.CodeRequeueSourceMissing)
+			return
+		}
+		a.Log.Error("requeue transcode dead letter", zap.Error(err), zap.Uint64("dead_letter_id", id))
+		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
+		return
+	}
+	resp.OK(c, gin.H{"ok": true, "id": id})
+}

--- a/internal/handler/auth_sqlite_test.go
+++ b/internal/handler/auth_sqlite_test.go
@@ -103,7 +103,7 @@ func newTestAPI(t *testing.T) (*API, *gin.Engine, *jwttoken.Manager) {
 	notifSvc := notification.NewNotificationService(db, rdb, log, userProv)
 	commentSvc := comment.NewCommentService(db, rdb, log, sens, notifSvc, userProv, videoProv, articleProv, dynamicProv)
 	userSvc := user.NewUserService(db, log)
-	videoSvc := video.NewVideoService(db, rdb, log, nil, nil)
+	videoSvc := video.NewVideoService(db, rdb, log, nil, noopMQ{})
 	dmSvc := dm.NewDmService(db, rdb, log)
 	favoriteSvc := favorite.NewFavoriteService(db, rdb, log, userProv, videoProv)
 	articleSvc := article.NewArticleService(db, rdb, log, nil)

--- a/internal/handler/integration_admin_dead_letter_test.go
+++ b/internal/handler/integration_admin_dead_letter_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package handler
+
+import (
+	"cakecake/internal/model/video"
+	"cakecake/internal/queue"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminTranscodeDeadLetter_ListAndRequeue(t *testing.T) {
+	api, r, _ := newTestAPI(t)
+	at := admintok(t, api)
+	require.NoError(t, api.DB.Create(&video.Video{ID: 20, UserID: 1, Title: "v", Status: video.StatusFailed, FailReason: "oss down"}).Error)
+	rawPath := filepath.Join(t.TempDir(), "raw.mp4")
+	require.NoError(t, os.WriteFile(rawPath, []byte("media"), 0o644))
+	payload, err := json.Marshal(map[string]interface{}{
+		"job": queue.TranscodeJob{VideoID: 20, RawPath: rawPath, RetryCount: 3}, "reason": "oss down",
+	})
+	require.NoError(t, err)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 20, RetryCount: 3, Reason: "oss down",
+		PayloadJSON: string(payload),
+	}
+	require.NoError(t, api.DB.Create(&dl).Error)
+
+	// List pending dead letters.
+	w := srveOK(t, r, areq("GET", "/api/v1/admin/transcode-dead-letters?status=pending", at, nil), http.StatusOK)
+	require.Contains(t, w.Body.String(), `"video_id":20`)
+
+	// Requeue.
+	w = srveOK(t, r, areq("POST", fmt.Sprintf("/api/v1/admin/transcode-dead-letters/%d/requeue", dl.ID), at, nil), http.StatusOK)
+	require.Contains(t, w.Body.String(), `"ok":true`)
+
+	// Row is now requeued and the video is back to processing.
+	w = srveOK(t, r, areq("GET", "/api/v1/admin/transcode-dead-letters?status=requeued", at, nil), http.StatusOK)
+	require.Contains(t, w.Body.String(), `"video_id":20`)
+	var v video.Video
+	require.NoError(t, api.DB.First(&v, 20).Error)
+	require.Equal(t, video.StatusProcessing, v.Status)
+
+	// Missing dead letter -> 404.
+	srveOK(t, r, areq("POST", "/api/v1/admin/transcode-dead-letters/99999/requeue", at, nil), http.StatusNotFound)
+}
+
+func TestAdminTranscodeDeadLetter_RequeueMissingSourceConflict(t *testing.T) {
+	api, r, _ := newTestAPI(t)
+	at := admintok(t, api)
+	require.NoError(t, api.DB.Create(&video.Video{ID: 22, UserID: 1, Title: "v", Status: video.StatusFailed}).Error)
+	payload, err := json.Marshal(map[string]interface{}{
+		"job": queue.TranscodeJob{VideoID: 22, RawPath: filepath.Join(t.TempDir(), "gone.mp4"), RetryCount: 3}, "reason": "x",
+	})
+	require.NoError(t, err)
+	dl := video.TranscodeDeadLetter{VideoID: 22, RetryCount: 3, Reason: "x", PayloadJSON: string(payload)}
+	require.NoError(t, api.DB.Create(&dl).Error)
+
+	w := srveOK(t, r, areq("POST", fmt.Sprintf("/api/v1/admin/transcode-dead-letters/%d/requeue", dl.ID), at, nil), http.StatusConflict)
+	require.Contains(t, w.Body.String(), `"code":40023`)
+	require.Contains(t, w.Body.String(), "原始文件已被清理")
+	var v video.Video
+	require.NoError(t, api.DB.First(&v, 22).Error)
+	require.Equal(t, video.StatusFailed, v.Status, "missing source must not touch the video")
+}
+
+func TestAdminTranscodeDeadLetter_ListShape(t *testing.T) {
+	api, r, _ := newTestAPI(t)
+	at := admintok(t, api)
+	require.NoError(t, api.DB.Create(&video.TranscodeDeadLetter{VideoID: 21, RetryCount: 1, Reason: "x", PayloadJSON: "{}"}).Error)
+
+	w := srveOK(t, r, areq("GET", "/api/v1/admin/transcode-dead-letters", at, nil), http.StatusOK)
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			Items []transcodeDeadLetterItem `json:"items"`
+			Total int64                     `json:"total"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, 0, body.Code)
+	require.Equal(t, int64(1), body.Data.Total)
+	require.Len(t, body.Data.Items, 1)
+	require.Equal(t, uint64(21), body.Data.Items[0].VideoID)
+}

--- a/internal/handler/integration_crud_test.go
+++ b/internal/handler/integration_crud_test.go
@@ -92,7 +92,7 @@ func setupHandlerIntegrationDB(t *testing.T) (*API, *gin.Engine, string) {
 				service.NewUserProvider(db), vsvc.NewVideoProvider(db),
 				service.NewArticleProvider(db), service.NewDynamicProvider(db)),
 			NotifSvc:          notification.NewNotificationService(db, rdb, zap.NewNop(), nil),
-			VideoSvc:          vsvc.NewVideoService(db, rdb, zap.NewNop(), nil, nil),
+			VideoSvc:          vsvc.NewVideoService(db, rdb, zap.NewNop(), nil, noopMQ{}),
 			BannerSvc:         banner.NewBannerService(db),
 			DmSvc:             dm.NewDmService(db, rdb, zap.NewNop()),
 			FavoriteSvc:       favorite.NewFavoriteService(db, rdb, zap.NewNop(), nil, nil),

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -321,6 +321,8 @@ func registerAdminRoutes(r *gin.Engine, pub, admin, authd *gin.RouterGroup, a *A
 	admin.POST("/agent-profiles/:id/avatar", a.AdminUploadAgentProfileAvatar)
 	admin.GET("/system-configs", a.AdminListSystemConfigs)
 	admin.PUT("/system-configs", a.AdminUpdateSystemConfig)
+	admin.GET("/transcode-dead-letters", a.AdminListTranscodeDeadLetters)
+	admin.POST("/transcode-dead-letters/:id/requeue", a.AdminRequeueTranscodeDeadLetter)
 }
 
 func registerStatsRoutes(r *gin.Engine, pub, admin, authd *gin.RouterGroup, a *API, jwtm *jwttoken.Manager) {

--- a/internal/model/video/transcode_dead_letter.go
+++ b/internal/model/video/transcode_dead_letter.go
@@ -11,4 +11,9 @@ type TranscodeDeadLetter struct {
 	RetryCount  int    `gorm:"type:bigint;not null;default:0"`
 	PayloadJSON string `gorm:"type:text"`
 	CreatedAt   time.Time
+	// ProcessedAt is set when the dead-letter consumer acks a message.
+	ProcessedAt *time.Time
+	// RequeuedAt / RequeuedCount track manual compensation via the admin API.
+	RequeuedAt    *time.Time
+	RequeuedCount int `gorm:"type:bigint;not null;default:0"`
 }

--- a/internal/service/video/deadletter_test.go
+++ b/internal/service/video/deadletter_test.go
@@ -1,0 +1,226 @@
+package video
+
+import (
+	"cakecake/internal/model/video"
+	"cakecake/internal/queue"
+	"cakecake/internal/service/servicetest"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+type fakeTranscodePublisher struct {
+	bodies [][]byte
+	err    error
+}
+
+func (f *fakeTranscodePublisher) PublishTranscode(_ context.Context, body []byte) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.bodies = append(f.bodies, body)
+	return nil
+}
+
+func deadLetterPayload(t *testing.T, job queue.TranscodeJob) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]interface{}{"job": job, "reason": "x"})
+	require.NoError(t, err)
+	return string(b)
+}
+
+func tempMedia(t *testing.T, name string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	require.NoError(t, os.WriteFile(p, []byte("media"), 0o644))
+	return p
+}
+
+func TestRequeueTranscodeDeadLetter_ResetsAndPublishes(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	mq := &fakeTranscodePublisher{}
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, mq)
+	ctx := context.Background()
+
+	servicetest.SeedUser(t, db, 1, "u")
+	require.NoError(t, db.Create(&video.Video{ID: 10, UserID: 1, Title: "v", Status: video.StatusFailed, FailReason: "oss down"}).Error)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 10, RetryCount: 3, Reason: "oss down",
+		PayloadJSON: deadLetterPayload(t, queue.TranscodeJob{VideoID: 10, RawPath: tempMedia(t, "raw.mp4"), RetryCount: 3}),
+	}
+	require.NoError(t, db.Create(&dl).Error)
+
+	require.NoError(t, svc.RequeueTranscodeDeadLetter(ctx, dl.ID))
+
+	require.Len(t, mq.bodies, 1)
+	var job queue.TranscodeJob
+	require.NoError(t, json.Unmarshal(mq.bodies[0], &job))
+	require.Equal(t, uint64(10), job.VideoID)
+	require.Zero(t, job.RetryCount)
+
+	var v video.Video
+	require.NoError(t, db.First(&v, 10).Error)
+	require.Equal(t, video.StatusProcessing, v.Status)
+	require.Empty(t, v.FailReason)
+
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.First(&row, dl.ID).Error)
+	require.NotNil(t, row.RequeuedAt)
+	require.Equal(t, 1, row.RequeuedCount)
+}
+
+func TestRequeueTranscodeDeadLetter_MissingSourceRejects(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	mq := &fakeTranscodePublisher{}
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, mq)
+	ctx := context.Background()
+
+	servicetest.SeedUser(t, db, 1, "u")
+	require.NoError(t, db.Create(&video.Video{ID: 10, UserID: 1, Title: "v", Status: video.StatusFailed}).Error)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 10, RetryCount: 3, Reason: "x",
+		PayloadJSON: deadLetterPayload(t, queue.TranscodeJob{VideoID: 10, RawPath: filepath.Join(t.TempDir(), "gone.mp4"), RetryCount: 3}),
+	}
+	require.NoError(t, db.Create(&dl).Error)
+
+	err := svc.RequeueTranscodeDeadLetter(ctx, dl.ID)
+	require.ErrorIs(t, err, ErrRequeueSourceMissing)
+	require.Empty(t, mq.bodies, "missing source must not publish")
+	var v video.Video
+	require.NoError(t, db.First(&v, 10).Error)
+	require.Equal(t, video.StatusFailed, v.Status)
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.First(&row, dl.ID).Error)
+	require.Nil(t, row.RequeuedAt)
+	require.Zero(t, row.RequeuedCount)
+}
+
+func TestRequeueTranscodeDeadLetter_MissingCoverRejects(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	mq := &fakeTranscodePublisher{}
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, mq)
+	ctx := context.Background()
+
+	servicetest.SeedUser(t, db, 1, "u")
+	require.NoError(t, db.Create(&video.Video{ID: 10, UserID: 1, Title: "v", Status: video.StatusFailed}).Error)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 10, RetryCount: 3, Reason: "x",
+		PayloadJSON: deadLetterPayload(t, queue.TranscodeJob{
+			VideoID: 10, RawPath: tempMedia(t, "raw.mp4"),
+			CoverPath: filepath.Join(t.TempDir(), "gone.jpg"), RetryCount: 3,
+		}),
+	}
+	require.NoError(t, db.Create(&dl).Error)
+
+	err := svc.RequeueTranscodeDeadLetter(ctx, dl.ID)
+	require.ErrorIs(t, err, ErrRequeueSourceMissing)
+	require.Empty(t, mq.bodies)
+}
+
+func TestRequeueTranscodeDeadLetter_PublishFailureRevertsVideoAndAuditRow(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	mq := &fakeTranscodePublisher{err: errors.New("broker down")}
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, mq)
+	ctx := context.Background()
+
+	servicetest.SeedUser(t, db, 1, "u")
+	require.NoError(t, db.Create(&video.Video{ID: 11, UserID: 1, Title: "v", Status: video.StatusFailed, FailReason: "old"}).Error)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 11, RetryCount: 3, Reason: "x",
+		PayloadJSON: deadLetterPayload(t, queue.TranscodeJob{VideoID: 11, RawPath: tempMedia(t, "raw.mp4"), RetryCount: 3}),
+	}
+	require.NoError(t, db.Create(&dl).Error)
+
+	err := svc.RequeueTranscodeDeadLetter(ctx, dl.ID)
+	require.Error(t, err)
+	var v video.Video
+	require.NoError(t, db.First(&v, 11).Error)
+	require.Equal(t, video.StatusFailed, v.Status)
+	require.Contains(t, v.FailReason, "requeue publish failed")
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.First(&row, dl.ID).Error)
+	require.Nil(t, row.RequeuedAt, "failed publish must not leave the audit row marked requeued")
+	require.Zero(t, row.RequeuedCount)
+}
+
+func TestRequeueTranscodeDeadLetter_PublishFailureRestoresPreviousAuditState(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	mq := &fakeTranscodePublisher{err: errors.New("broker down")}
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, mq)
+	ctx := context.Background()
+
+	servicetest.SeedUser(t, db, 1, "u")
+	require.NoError(t, db.Create(&video.Video{ID: 12, UserID: 1, Title: "v", Status: video.StatusFailed}).Error)
+	prevRequeuedAt := time.Now().Add(-time.Hour)
+	prevProcessedAt := time.Now().Add(-2 * time.Hour)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 12, RetryCount: 3, Reason: "x", RequeuedAt: &prevRequeuedAt, RequeuedCount: 2, ProcessedAt: &prevProcessedAt,
+		PayloadJSON: deadLetterPayload(t, queue.TranscodeJob{VideoID: 12, RawPath: tempMedia(t, "raw.mp4"), RetryCount: 3}),
+	}
+	require.NoError(t, db.Create(&dl).Error)
+
+	err := svc.RequeueTranscodeDeadLetter(ctx, dl.ID)
+	require.Error(t, err)
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.First(&row, dl.ID).Error)
+	require.NotNil(t, row.RequeuedAt)
+	require.Equal(t, prevRequeuedAt.Unix(), row.RequeuedAt.Unix(), "requeued_at must be restored to the pre-attempt value")
+	require.Equal(t, 2, row.RequeuedCount, "requeued_count must be restored to the pre-attempt value")
+	require.NotNil(t, row.ProcessedAt)
+	require.Equal(t, prevProcessedAt.Unix(), row.ProcessedAt.Unix(), "processed_at must be restored to the pre-attempt value")
+}
+
+func TestRequeueTranscodeDeadLetter_NoMQRollsBackAuditRow(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, nil)
+	ctx := context.Background()
+
+	servicetest.SeedUser(t, db, 1, "u")
+	require.NoError(t, db.Create(&video.Video{ID: 13, UserID: 1, Title: "v", Status: video.StatusFailed}).Error)
+	dl := video.TranscodeDeadLetter{
+		VideoID: 13, RetryCount: 3, Reason: "x",
+		PayloadJSON: deadLetterPayload(t, queue.TranscodeJob{VideoID: 13, RawPath: tempMedia(t, "raw.mp4"), RetryCount: 3}),
+	}
+	require.NoError(t, db.Create(&dl).Error)
+
+	err := svc.RequeueTranscodeDeadLetter(ctx, dl.ID)
+	require.Error(t, err)
+	var v video.Video
+	require.NoError(t, db.First(&v, 13).Error)
+	require.Equal(t, video.StatusFailed, v.Status)
+	require.Contains(t, v.FailReason, "transcode queue not configured")
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.First(&row, dl.ID).Error)
+	require.Nil(t, row.RequeuedAt)
+	require.Zero(t, row.RequeuedCount)
+}
+
+func TestListTranscodeDeadLetters_Filters(t *testing.T) {
+	db := servicetest.NewDB(t)
+	_, rdb := servicetest.NewRedis(t)
+	svc := NewVideoService(db, rdb, zap.NewNop(), nil, nil)
+	ctx := context.Background()
+
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{VideoID: 1, RetryCount: 1, Reason: "pending"}).Error)
+	now := time.Now()
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{VideoID: 2, RetryCount: 1, Reason: "requeued", RequeuedAt: &now}).Error)
+
+	rows, total, err := svc.ListTranscodeDeadLetters(ctx, TranscodeDeadLetterFilter{Page: 1, PageSize: 10, Status: "requeued"})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, rows, 1)
+	require.Equal(t, uint64(2), rows[0].VideoID)
+}

--- a/internal/service/video/interfaces.go
+++ b/internal/service/video/interfaces.go
@@ -51,6 +51,20 @@ type VideoProvider interface {
 	CountByStatus(ctx context.Context, status string) (int64, error)
 	// ToggleVideoLike creates/removes a like row and adjusts like_count (business check done by caller).
 	ToggleVideoLike(ctx context.Context, userID, videoID uint64) (bool, error)
+	// ListTranscodeDeadLetters lists dead-letter audit rows with pagination.
+	ListTranscodeDeadLetters(ctx context.Context, f TranscodeDeadLetterFilter) ([]video.TranscodeDeadLetter, int64, error)
+	// GetTranscodeDeadLetter loads one dead-letter audit row.
+	GetTranscodeDeadLetter(ctx context.Context, id uint64) (*video.TranscodeDeadLetter, error)
+	// MarkTranscodeDeadLetterRequeued records a manual requeue.
+	MarkTranscodeDeadLetterRequeued(ctx context.Context, id uint64, at time.Time) error
+	// RevertTranscodeDeadLetterRequeue restores lifecycle fields to their
+	// pre-requeue values after a failed publish, so "requeued" never lies.
+	RevertTranscodeDeadLetterRequeue(ctx context.Context, id uint64, prevRequeuedAt *time.Time, prevRequeuedCount int, prevProcessedAt *time.Time) error
+	// ResetVideoForTranscodeRequeue moves a video back to processing and clears
+	// stale output fields so a requeued job is not skipped by the idempotency guard.
+	ResetVideoForTranscodeRequeue(ctx context.Context, videoID uint64) error
+	// MarkVideoFailedByID marks a video failed (used to revert a failed requeue).
+	MarkVideoFailedByID(ctx context.Context, videoID uint64, reason string) error
 	// PublishVideo marks a video published and (re)indexes search. Monolith-phase flow.
 	PublishVideo(ctx context.Context, esc *search.Client, log *zap.Logger, videoID uint64, adminID *uint64) error
 	// AdminDeleteVideoCascade runs the cascade-delete callback inside a transaction.

--- a/internal/service/video/metrics.go
+++ b/internal/service/video/metrics.go
@@ -1,0 +1,19 @@
+package video
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	transcodeRequeuedTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "cakecake",
+		Subsystem: "transcode",
+		Name:      "requeued_total",
+		Help:      "Total transcode dead letters requeued via the admin API.",
+	})
+)
+
+func incrTranscodeRequeued() {
+	transcodeRequeuedTotal.Inc()
+}

--- a/internal/service/video/provider.go
+++ b/internal/service/video/provider.go
@@ -21,6 +21,84 @@ type VideoProviderImpl struct {
 	db *gorm.DB
 }
 
+// TranscodeDeadLetterFilter filters dead-letter audit rows.
+type TranscodeDeadLetterFilter struct {
+	Page     int
+	PageSize int
+	Status   string // pending | requeued | processed | "" (all)
+}
+
+func (p *VideoProviderImpl) ListTranscodeDeadLetters(ctx context.Context, f TranscodeDeadLetterFilter) ([]video.TranscodeDeadLetter, int64, error) {
+	q := p.db.WithContext(ctx).Model(&video.TranscodeDeadLetter{})
+	switch f.Status {
+	case "pending":
+		q = q.Where("processed_at IS NULL AND requeued_at IS NULL")
+	case "requeued":
+		q = q.Where("requeued_at IS NOT NULL")
+	case "processed":
+		q = q.Where("processed_at IS NOT NULL")
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	page, size := f.Page, f.PageSize
+	if page < 1 {
+		page = 1
+	}
+	if size < 1 {
+		size = 20
+	}
+	var rows []video.TranscodeDeadLetter
+	if err := q.Order("id DESC").Limit(size).Offset((page - 1) * size).Find(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+	return rows, total, nil
+}
+
+func (p *VideoProviderImpl) GetTranscodeDeadLetter(ctx context.Context, id uint64) (*video.TranscodeDeadLetter, error) {
+	var row video.TranscodeDeadLetter
+	if err := p.db.WithContext(ctx).First(&row, id).Error; err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
+func (p *VideoProviderImpl) MarkTranscodeDeadLetterRequeued(ctx context.Context, id uint64, at time.Time) error {
+	return p.db.WithContext(ctx).Model(&video.TranscodeDeadLetter{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"requeued_at":    at,
+		"requeued_count": gorm.Expr("requeued_count + 1"),
+		"processed_at":   nil,
+	}).Error
+}
+
+func (p *VideoProviderImpl) RevertTranscodeDeadLetterRequeue(ctx context.Context, id uint64, prevRequeuedAt *time.Time, prevRequeuedCount int, prevProcessedAt *time.Time) error {
+	return p.db.WithContext(ctx).Model(&video.TranscodeDeadLetter{}).Where("id = ?", id).Updates(map[string]interface{}{
+		"requeued_at":    prevRequeuedAt,
+		"requeued_count": prevRequeuedCount,
+		"processed_at":   prevProcessedAt,
+	}).Error
+}
+
+func (p *VideoProviderImpl) ResetVideoForTranscodeRequeue(ctx context.Context, videoID uint64) error {
+	return p.db.WithContext(ctx).Model(&video.Video{}).Where("id = ?", videoID).Updates(map[string]interface{}{
+		"status":      video.StatusProcessing,
+		"fail_reason": "",
+		"video_url":   "",
+		"cover_url":   "",
+	}).Error
+}
+
+func (p *VideoProviderImpl) MarkVideoFailedByID(ctx context.Context, videoID uint64, reason string) error {
+	r := []rune(reason)
+	if len(r) > 1900 {
+		reason = string(r[:1900])
+	}
+	return p.db.WithContext(ctx).Model(&video.Video{}).Where("id = ?", videoID).Updates(map[string]interface{}{
+		"status": video.StatusFailed, "fail_reason": reason,
+	}).Error
+}
+
 var _ VideoProvider = (*VideoProviderImpl)(nil)
 
 // NewVideoProvider creates a gorm-backed VideoProvider implementation.

--- a/internal/service/video/provider.go
+++ b/internal/service/video/provider.go
@@ -28,6 +28,8 @@ type TranscodeDeadLetterFilter struct {
 	Status   string // pending | requeued | processed | "" (all)
 }
 
+// ListTranscodeDeadLetters lists dead-letter audit rows with pagination and
+// optional status filtering.
 func (p *VideoProviderImpl) ListTranscodeDeadLetters(ctx context.Context, f TranscodeDeadLetterFilter) ([]video.TranscodeDeadLetter, int64, error) {
 	q := p.db.WithContext(ctx).Model(&video.TranscodeDeadLetter{})
 	switch f.Status {
@@ -56,6 +58,7 @@ func (p *VideoProviderImpl) ListTranscodeDeadLetters(ctx context.Context, f Tran
 	return rows, total, nil
 }
 
+// GetTranscodeDeadLetter loads a single dead-letter audit row by id.
 func (p *VideoProviderImpl) GetTranscodeDeadLetter(ctx context.Context, id uint64) (*video.TranscodeDeadLetter, error) {
 	var row video.TranscodeDeadLetter
 	if err := p.db.WithContext(ctx).First(&row, id).Error; err != nil {
@@ -64,6 +67,7 @@ func (p *VideoProviderImpl) GetTranscodeDeadLetter(ctx context.Context, id uint6
 	return &row, nil
 }
 
+// MarkTranscodeDeadLetterRequeued records a manual requeue on the audit row.
 func (p *VideoProviderImpl) MarkTranscodeDeadLetterRequeued(ctx context.Context, id uint64, at time.Time) error {
 	return p.db.WithContext(ctx).Model(&video.TranscodeDeadLetter{}).Where("id = ?", id).Updates(map[string]interface{}{
 		"requeued_at":    at,
@@ -72,6 +76,8 @@ func (p *VideoProviderImpl) MarkTranscodeDeadLetterRequeued(ctx context.Context,
 	}).Error
 }
 
+// RevertTranscodeDeadLetterRequeue restores lifecycle fields to their
+// pre-requeue values after a failed publish.
 func (p *VideoProviderImpl) RevertTranscodeDeadLetterRequeue(ctx context.Context, id uint64, prevRequeuedAt *time.Time, prevRequeuedCount int, prevProcessedAt *time.Time) error {
 	return p.db.WithContext(ctx).Model(&video.TranscodeDeadLetter{}).Where("id = ?", id).Updates(map[string]interface{}{
 		"requeued_at":    prevRequeuedAt,
@@ -80,6 +86,8 @@ func (p *VideoProviderImpl) RevertTranscodeDeadLetterRequeue(ctx context.Context
 	}).Error
 }
 
+// ResetVideoForTranscodeRequeue moves a video back to processing and clears
+// stale output fields so a requeued job is not skipped by the idempotency guard.
 func (p *VideoProviderImpl) ResetVideoForTranscodeRequeue(ctx context.Context, videoID uint64) error {
 	return p.db.WithContext(ctx).Model(&video.Video{}).Where("id = ?", videoID).Updates(map[string]interface{}{
 		"status":      video.StatusProcessing,
@@ -89,6 +97,7 @@ func (p *VideoProviderImpl) ResetVideoForTranscodeRequeue(ctx context.Context, v
 	}).Error
 }
 
+// MarkVideoFailedByID marks a video failed with a rune-safe reason.
 func (p *VideoProviderImpl) MarkVideoFailedByID(ctx context.Context, videoID uint64, reason string) error {
 	r := []rune(reason)
 	if len(r) > 1900 {

--- a/internal/service/video/video.go
+++ b/internal/service/video/video.go
@@ -5,7 +5,10 @@ import (
 	"cakecake/internal/pkg/dbtx"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -24,6 +27,10 @@ type VideoService struct {
 	es     *search.Client
 	mq     queue.TranscodePublisher
 }
+
+// ErrRequeueSourceMissing reports that the raw media (or user cover) behind a
+// dead letter no longer exists on disk, so requeue cannot succeed.
+var ErrRequeueSourceMissing = errors.New("requeue source media missing")
 
 // VideoProbe is the media-duration probe used by the video services. It is a
 // variable so tests can substitute a deterministic probe without invoking
@@ -57,6 +64,87 @@ func (s *VideoService) EnqueueTranscode(ctx context.Context, videoID uint64, raw
 		return err
 	}
 	return s.PublishTranscode(ctx, body)
+}
+
+// ListTranscodeDeadLetters returns dead-letter audit rows with pagination.
+func (s *VideoService) ListTranscodeDeadLetters(ctx context.Context, f TranscodeDeadLetterFilter) ([]video.TranscodeDeadLetter, int64, error) {
+	return s.videos.ListTranscodeDeadLetters(ctx, f)
+}
+
+// RequeueTranscodeDeadLetter re-publishes a dead letter to the main queue with
+// retries reset, and marks the audit row requeued. The video is moved back to
+// processing first so the idempotency guard does not skip the redelivery.
+func (s *VideoService) RequeueTranscodeDeadLetter(ctx context.Context, id uint64) error {
+	row, err := s.videos.GetTranscodeDeadLetter(ctx, id)
+	if err != nil {
+		return err
+	}
+	var payload struct {
+		Job    queue.TranscodeJob `json:"job"`
+		Reason string             `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(row.PayloadJSON), &payload); err != nil {
+		return fmt.Errorf("dead letter payload invalid: %w", err)
+	}
+	if payload.Job.VideoID == 0 {
+		return fmt.Errorf("dead letter payload missing job")
+	}
+	// The dead letter keeps RawPath/CoverPath on purpose, but old rows or
+	// manual file cleanup can leave them gone. Fail fast with a clear error
+	// instead of publishing a job that is guaranteed to fail again.
+	if _, err := os.Stat(payload.Job.RawPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%w: raw media %s", ErrRequeueSourceMissing, payload.Job.RawPath)
+		}
+		return fmt.Errorf("check raw media before requeue: %w", err)
+	}
+	if payload.Job.CoverPath != "" {
+		if _, err := os.Stat(payload.Job.CoverPath); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("%w: cover media %s", ErrRequeueSourceMissing, payload.Job.CoverPath)
+			}
+			return fmt.Errorf("check cover media before requeue: %w", err)
+		}
+	}
+	job := payload.Job
+	job.RetryCount = 0
+	body, err := json.Marshal(job)
+	if err != nil {
+		return err
+	}
+
+	// Keep the pre-requeue audit state so a failed publish can be compensated:
+	// "requeued" must mean the message actually reached the main queue, not
+	// merely that an attempt was made.
+	prevRequeuedAt, prevRequeuedCount, prevProcessedAt := row.RequeuedAt, row.RequeuedCount, row.ProcessedAt
+
+	// DB first, then publish: if publish fails, revert both the video and the
+	// audit row so the user sees a failed video and a still-pending dead letter.
+	if err := s.videos.ResetVideoForTranscodeRequeue(ctx, job.VideoID); err != nil {
+		return err
+	}
+	if err := s.videos.MarkTranscodeDeadLetterRequeued(ctx, id, time.Now()); err != nil {
+		_ = s.videos.MarkVideoFailedByID(ctx, job.VideoID, "requeue db mark failed: "+err.Error())
+		return err
+	}
+	revertAudit := func(reason string) {
+		if rerr := s.videos.RevertTranscodeDeadLetterRequeue(ctx, id, prevRequeuedAt, prevRequeuedCount, prevProcessedAt); rerr != nil {
+			s.log.Error("revert dead letter requeue audit failed",
+				zap.Uint64("dead_letter_id", id),
+				zap.Error(rerr))
+		}
+		_ = s.videos.MarkVideoFailedByID(ctx, job.VideoID, reason)
+	}
+	if s.mq == nil {
+		revertAudit("requeue failed: transcode queue not configured")
+		return fmt.Errorf("transcode queue not configured")
+	}
+	if err := s.mq.PublishTranscode(ctx, body); err != nil {
+		revertAudit("requeue publish failed: " + err.Error())
+		return err
+	}
+	incrTranscodeRequeued()
+	return nil
 }
 
 // ProbeDurationSeconds probes a raw media file's duration via ffprobe.

--- a/internal/worker/metrics.go
+++ b/internal/worker/metrics.go
@@ -1,0 +1,20 @@
+package worker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Transcode pipeline observability for the dead-letter lifecycle.
+var (
+	transcodeDeadLettersTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "cakecake",
+		Subsystem: "transcode",
+		Name:      "dead_letters_total",
+		Help:      "Total transcode jobs dead-lettered (retries exhausted or republish failed).",
+	})
+)
+
+func incrTranscodeDeadLetters() {
+	transcodeDeadLettersTotal.Inc()
+}

--- a/internal/worker/transcode.go
+++ b/internal/worker/transcode.go
@@ -112,6 +112,30 @@ func handleDeliveryWith(ctx context.Context, cfg *config.C, db *gorm.DB, pubCh t
 		return
 	}
 	lg.Info("transcode job received", zap.Uint64("video_id", job.VideoID), zap.String("raw", job.RawPath))
+	// At-least-once redelivery guard: a crash between the DB update and the
+	// Ack can redeliver an already-processed job. If the video already reached
+	// a terminal transcode state, skip and Ack instead of re-transcoding.
+	if db != nil {
+		var v video.Video
+		if err := db.WithContext(ctx).First(&v, job.VideoID).Error; err != nil {
+			lg.Warn("transcode video missing, skipping redelivery",
+				zap.Uint64("video_id", job.VideoID), zap.Error(err))
+			cleanupPaths(job.RawPath, job.CoverPath)
+			ackDelivery(lg, d)
+			return
+		}
+		switch v.Status {
+		case video.StatusPublished, video.StatusPendingReview, video.StatusFailed, video.StatusRejected:
+			lg.Info("transcode job already terminal, skipping redelivery",
+				zap.Uint64("video_id", job.VideoID),
+				zap.String("status", v.Status),
+				zap.String("video_url", v.VideoURL),
+			)
+			cleanupPaths(job.RawPath, job.CoverPath)
+			ackDelivery(lg, d)
+			return
+		}
+	}
 	if ossClient == nil {
 		lg.Error("oss not configured, failing job", zap.Uint64("video_id", job.VideoID))
 		failVideo(db, job.VideoID, "OSS 未配置")
@@ -258,6 +282,7 @@ func truncate(s string, n int) string {
 // deadLetterTranscode publishes an exhausted job to the dead-letter queue and
 // records it in the DB, so failed transcodes are observable and compensable.
 func deadLetterTranscode(ctx context.Context, db *gorm.DB, pubCh transcodePublisher, lg *zap.Logger, job TranscodeJob, reason string) {
+	incrTranscodeDeadLetters()
 	if pubCh != nil {
 		body, _ := json.Marshal(job)
 		if err := pubCh.PublishWithContext(ctx, "", queue.TranscodeDeadQueue, false, false, amqp.Publishing{
@@ -284,12 +309,17 @@ func deadLetterTranscode(ctx context.Context, db *gorm.DB, pubCh transcodePublis
 }
 
 // requeueOrFail re-enqueues on retryable failure and returns true (caller must preserve RawPath / user cover).
-// On terminal failure returns false, and has already deleted RawPath, CoverPath and local files in terminalLocalExtras.
+// On terminal failure returns false, and has already deleted only the
+// intermediate files in terminalLocalExtras. RawPath/CoverPath are
+// intentionally KEPT: the dead letter is the compensation trail, and the
+// admin requeue re-runs ffmpeg from those files. They are removed either by
+// a later successful transcode or by retention cleanup once the dead letter
+// is resolved and never requeued.
 func requeueOrFail(ctx context.Context, cfg *config.C, db *gorm.DB, pubCh transcodePublisher, lg *zap.Logger, job TranscodeJob, reason string, terminalLocalExtras ...string) bool {
 	if job.RetryCount >= 3 {
 		deadLetterTranscode(ctx, db, pubCh, lg, job, reason)
 		failVideo(db, job.VideoID, reason)
-		cleanupPaths(append([]string{job.RawPath, job.CoverPath}, terminalLocalExtras...)...)
+		cleanupPaths(terminalLocalExtras...)
 		lg.Error("transcode exhausted retries", zap.Uint64("video_id", job.VideoID))
 		return false
 	}
@@ -306,7 +336,7 @@ func requeueOrFail(ctx context.Context, cfg *config.C, db *gorm.DB, pubCh transc
 		lg.Error("republish transcode job", zap.Error(err))
 		deadLetterTranscode(ctx, db, pubCh, lg, job, reason)
 		failVideo(db, job.VideoID, reason)
-		cleanupPaths(append([]string{job.RawPath, job.CoverPath}, terminalLocalExtras...)...)
+		cleanupPaths(terminalLocalExtras...)
 		return false
 	}
 	return true
@@ -336,7 +366,7 @@ func StartTranscodeDeadConsumer(ctx context.Context, cfg *config.C, db *gorm.DB,
 		if err != nil {
 			lg.Warn("transcode dead consumer: subscribe", zap.Error(err))
 		} else {
-			consumeTranscodeDead(ctx, ch, msgs, lg)
+			consumeTranscodeDead(ctx, ch, msgs, lg, db)
 		}
 		select {
 		case <-ctx.Done():
@@ -348,7 +378,7 @@ func StartTranscodeDeadConsumer(ctx context.Context, cfg *config.C, db *gorm.DB,
 
 // consumeTranscodeDead drains one dead-letter channel. It returns when the
 // channel closes or the context is cancelled; the caller reconnects.
-func consumeTranscodeDead(ctx context.Context, ch interface{ Close() error }, msgs <-chan amqp.Delivery, lg *zap.Logger) {
+func consumeTranscodeDead(ctx context.Context, ch interface{ Close() error }, msgs <-chan amqp.Delivery, lg *zap.Logger, db *gorm.DB) {
 	defer ch.Close()
 	for {
 		select {
@@ -358,13 +388,14 @@ func consumeTranscodeDead(ctx context.Context, ch interface{ Close() error }, ms
 			if !ok {
 				return
 			}
-			handleTranscodeDeadLetter(d, lg)
+			handleTranscodeDeadLetter(d, lg, db)
 		}
 	}
 }
 
-// handleTranscodeDeadLetter logs and acks a single dead letter.
-func handleTranscodeDeadLetter(d amqp.Delivery, lg *zap.Logger) {
+// handleTranscodeDeadLetter logs and acks a single dead letter, then marks the
+// matching audit row processed so retention can eventually clean it up.
+func handleTranscodeDeadLetter(d amqp.Delivery, lg *zap.Logger, db *gorm.DB) {
 	var job TranscodeJob
 	_ = json.Unmarshal(d.Body, &job)
 	lg.Warn("transcode dead letter consumed",
@@ -372,4 +403,71 @@ func handleTranscodeDeadLetter(d amqp.Delivery, lg *zap.Logger) {
 		zap.Int("retry_count", job.RetryCount),
 	)
 	_ = d.Ack(false)
+	if db != nil {
+		if err := db.Model(&video.TranscodeDeadLetter{}).
+			Where("video_id = ? AND retry_count = ? AND processed_at IS NULL", job.VideoID, job.RetryCount).
+			Order("id DESC").
+			Limit(1).
+			Update("processed_at", time.Now()).Error; err != nil {
+			lg.Warn("mark transcode dead letter processed", zap.Uint64("video_id", job.VideoID), zap.Error(err))
+		}
+	}
+}
+
+const (
+	transcodeDeadRetention     = 30 * 24 * time.Hour
+	transcodeDeadCleanInterval = 24 * time.Hour
+)
+
+// StartTranscodeDeadRetention periodically archives resolved dead letters
+// (processed or requeued) older than the retention window.
+func StartTranscodeDeadRetention(ctx context.Context, db *gorm.DB, lg *zap.Logger) {
+	if db == nil {
+		return
+	}
+	cleanupTranscodeDeadLetters(db, time.Now().Add(-transcodeDeadRetention), lg)
+	t := time.NewTicker(transcodeDeadCleanInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			cleanupTranscodeDeadLetters(db, time.Now().Add(-transcodeDeadRetention), lg)
+		}
+	}
+}
+
+// cleanupTranscodeDeadLetters deletes resolved dead letters (processed or
+// requeued) older than the retention cutoff. It returns the deleted row count.
+func cleanupTranscodeDeadLetters(db *gorm.DB, cutoff time.Time, lg *zap.Logger) int64 {
+	// Rows that were consumed and never requeued are safe to archive: no
+	// successor job references their raw media. Remove those files before
+	// deleting the audit rows. Rows that were requeued may still be feeding a
+	// successor job, so their files are left untouched.
+	var archival []video.TranscodeDeadLetter
+	if err := db.Where("processed_at IS NOT NULL AND processed_at < ? AND requeued_at IS NULL", cutoff).
+		Find(&archival).Error; err != nil {
+		lg.Warn("scan transcode dead letters for archival", zap.Error(err))
+		return 0
+	}
+	for i := range archival {
+		var payload struct {
+			Job TranscodeJob `json:"job"`
+		}
+		if err := json.Unmarshal([]byte(archival[i].PayloadJSON), &payload); err == nil {
+			cleanupPaths(payload.Job.RawPath, payload.Job.CoverPath)
+		}
+	}
+	res := db.Where("processed_at IS NOT NULL AND processed_at < ?", cutoff).
+		Or("requeued_at IS NOT NULL AND requeued_at < ?", cutoff).
+		Delete(&video.TranscodeDeadLetter{})
+	if res.Error != nil {
+		lg.Warn("cleanup transcode dead letters", zap.Error(res.Error))
+		return 0
+	}
+	if res.RowsAffected > 0 {
+		lg.Info("cleaned transcode dead letters", zap.Int64("rows", res.RowsAffected))
+	}
+	return res.RowsAffected
 }

--- a/internal/worker/transcode_behavioral_test.go
+++ b/internal/worker/transcode_behavioral_test.go
@@ -5,11 +5,14 @@ import (
 	"cakecake/internal/data"
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
+	"cakecake/internal/queue"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/stretchr/testify/require"
@@ -131,4 +134,161 @@ func TestBehavioral_TranscodePermanentFailure(t *testing.T) {
 	require.NotEmpty(t, v.FailReason)
 	_, err := os.Stat(rawPath)
 	require.ErrorIs(t, err, os.ErrNotExist, "raw file should be removed after terminal failure")
+}
+
+// TestBehavioral_TranscodeExhaustedRetriesKeepsRawSource verifies that going
+// to the dead letter preserves the original media: the admin requeue re-runs
+// ffmpeg from RawPath/CoverPath, so they must survive the terminal path.
+func TestBehavioral_TranscodeExhaustedRetriesKeepsRawSource(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	require.NoError(t, db.Create(&video.Video{ID: 21, UserID: 1, Title: "v", Status: video.StatusProcessing}).Error)
+
+	tmp := t.TempDir()
+	rawPath := filepath.Join(tmp, "raw.mp4")
+	coverPath := filepath.Join(tmp, "cover.png")
+	require.NoError(t, os.WriteFile(rawPath, []byte("raw"), 0o644))
+	require.NoError(t, os.WriteFile(coverPath, []byte("cover"), 0o644))
+
+	body, _ := json.Marshal(TranscodeJob{VideoID: 21, RawPath: rawPath, CoverPath: coverPath, RetryCount: 3})
+	ack := &fakeAck{}
+	store := &recordingStore{}
+	pub := &fakePublisher{}
+	ff := &fakeFFmpeg{transcodeErr: errors.New("retryable"), transcodeStderr: "boom", permStderr: "other"}
+	handleDeliveryWith(context.Background(), &config.C{TempUploadDir: tmp}, db, pub, store, nil,
+		amqp.Delivery{Body: body, Acknowledger: ack}, ff, zap.NewNop())
+
+	require.Equal(t, 1, ack.acked)
+	require.Empty(t, store.uploads)
+	require.Equal(t, []string{queue.TranscodeDeadQueue}, pub.keys, "exhausted job must be dead-lettered")
+	var v video.Video
+	require.NoError(t, db.First(&v, 21).Error)
+	require.Equal(t, video.StatusFailed, v.Status)
+	var rec video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 21).First(&rec).Error)
+	require.Equal(t, 3, rec.RetryCount)
+	_, err := os.Stat(rawPath)
+	require.NoError(t, err, "raw source must be kept for admin requeue")
+	_, err = os.Stat(coverPath)
+	require.NoError(t, err, "cover source must be kept for admin requeue")
+}
+
+// TestBehavioral_TranscodeRepublishFailureKeepsRawSource covers the second
+// dead-letter path: republishing a retryable job fails, so the job is
+// dead-lettered; the original media must still be kept for compensation.
+func TestBehavioral_TranscodeRepublishFailureKeepsRawSource(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	require.NoError(t, db.Create(&video.Video{ID: 22, UserID: 1, Title: "v", Status: video.StatusProcessing}).Error)
+
+	tmp := t.TempDir()
+	rawPath := filepath.Join(tmp, "raw.mp4")
+	require.NoError(t, os.WriteFile(rawPath, []byte("raw"), 0o644))
+
+	oldDelay := transcodeRetryBaseDelay
+	transcodeRetryBaseDelay = time.Millisecond
+	defer func() { transcodeRetryBaseDelay = oldDelay }()
+
+	body, _ := json.Marshal(TranscodeJob{VideoID: 22, RawPath: rawPath, RetryCount: 2})
+	ack := &fakeAck{}
+	store := &recordingStore{}
+	pub := &fakePublisher{err: errors.New("broker down")}
+	ff := &fakeFFmpeg{transcodeErr: errors.New("retryable"), transcodeStderr: "boom", permStderr: "other"}
+	handleDeliveryWith(context.Background(), &config.C{TempUploadDir: tmp}, db, pub, store, nil,
+		amqp.Delivery{Body: body, Acknowledger: ack}, ff, zap.NewNop())
+
+	require.Equal(t, 1, ack.acked)
+	var v video.Video
+	require.NoError(t, db.First(&v, 22).Error)
+	require.Equal(t, video.StatusFailed, v.Status)
+	var rec video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 22).First(&rec).Error)
+	require.Equal(t, 3, rec.RetryCount, "republish failure stores the incremented retry count")
+	_, err := os.Stat(rawPath)
+	require.NoError(t, err, "raw source must be kept after republish failure")
+}
+
+type spyFFmpeg struct {
+	called bool
+}
+
+func (s *spyFFmpeg) TranscodeToH264MP4(_, _ string) (string, error) {
+	s.called = true
+	return "", errors.New("should not run on redelivery")
+}
+
+func (s *spyFFmpeg) ScreenshotJPEG(_, _ string, _ float64) (string, error) {
+	s.called = true
+	return "", errors.New("should not run on redelivery")
+}
+
+func (s *spyFFmpeg) IsPermanentTranscodeFailure(string) bool { return false }
+
+// TestBehavioral_TranscodeRedelivery_SkipsTerminalState verifies the
+// at-least-once idempotency guard: a redelivered job for a video that already
+// reached a terminal transcode state is acked and skipped without touching
+// ffmpeg or OSS.
+func TestBehavioral_TranscodeRedelivery_SkipsTerminalState(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+	}{
+		{"published", video.StatusPublished},
+		{"pending_review", video.StatusPendingReview},
+		{"failed", video.StatusFailed},
+		{"rejected", video.StatusRejected},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := newBehavioralWorkerDB(t)
+			require.NoError(t, db.Create(&user.User{ID: 1, Username: "u", PasswordHash: "x"}).Error)
+			require.NoError(t, db.Create(&video.Video{
+				ID: 50, UserID: 1, Title: "v", Status: tc.status,
+				VideoURL: "https://cdn.example.com/50.mp4",
+			}).Error)
+
+			tmp := t.TempDir()
+			raw := filepath.Join(tmp, "raw.mp4")
+			cover := filepath.Join(tmp, "cover.png")
+			require.NoError(t, os.WriteFile(raw, []byte("raw"), 0o644))
+			require.NoError(t, os.WriteFile(cover, []byte("cover"), 0o644))
+
+			ack := &fakeAck{}
+			store := &recordingStore{}
+			ff := &spyFFmpeg{}
+			handleDeliveryWith(context.Background(), &config.C{TempUploadDir: tmp}, db, nil, store, nil,
+				deliveryForVideoID(50, raw, cover, ack), ff, zap.NewNop())
+
+			require.Equal(t, 1, ack.acked, "terminal redelivery must be acked")
+			require.False(t, ff.called, "terminal redelivery must not run ffmpeg")
+			require.Empty(t, store.uploads, "terminal redelivery must not upload OSS")
+			var v video.Video
+			require.NoError(t, db.First(&v, 50).Error)
+			require.Equal(t, tc.status, v.Status)
+			_, err := os.Stat(raw)
+			require.ErrorIs(t, err, os.ErrNotExist, "staging raw should be cleaned on skip")
+			_, err = os.Stat(cover)
+			require.ErrorIs(t, err, os.ErrNotExist, "staging cover should be cleaned on skip")
+		})
+	}
+}
+
+// TestBehavioral_TranscodeRedelivery_MissingVideoAcks verifies that a
+// redelivered job whose video row no longer exists is acked and dropped
+// instead of failing the queue or running ffmpeg.
+func TestBehavioral_TranscodeRedelivery_MissingVideoAcks(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	tmp := t.TempDir()
+	raw := filepath.Join(tmp, "raw.mp4")
+	require.NoError(t, os.WriteFile(raw, []byte("raw"), 0o644))
+
+	ack := &fakeAck{}
+	ff := &spyFFmpeg{}
+	store := &recordingStore{}
+	handleDeliveryWith(context.Background(), &config.C{TempUploadDir: tmp}, db, nil, store, nil,
+		deliveryForVideoID(999, raw, "", ack), ff, zap.NewNop())
+
+	require.Equal(t, 1, ack.acked)
+	require.False(t, ff.called)
+	require.Empty(t, store.uploads)
+	_, err := os.Stat(raw)
+	require.ErrorIs(t, err, os.ErrNotExist, "staging raw should be cleaned on missing video")
 }

--- a/internal/worker/transcode_dead_consumer_test.go
+++ b/internal/worker/transcode_dead_consumer_test.go
@@ -1,8 +1,11 @@
 package worker
 
 import (
+	"cakecake/internal/model/video"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -40,8 +43,22 @@ func (f *fakeDeadSubscriber) NewTranscodeDeadConsumer(_ string) (interface{ Clos
 func TestHandleTranscodeDeadLetter_Acks(t *testing.T) {
 	ack := &fakeAck{}
 	body, _ := json.Marshal(TranscodeJob{VideoID: 42, RetryCount: 3})
-	handleTranscodeDeadLetter(amqp.Delivery{Body: body, Acknowledger: ack}, zap.NewNop())
+	handleTranscodeDeadLetter(amqp.Delivery{Body: body, Acknowledger: ack}, zap.NewNop(), nil)
 	require.Equal(t, 1, ack.acked)
+}
+
+func TestHandleTranscodeDeadLetter_MarksProcessed(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{
+		VideoID: 42, RetryCount: 3, Reason: "x", PayloadJSON: "{}",
+	}).Error)
+	ack := &fakeAck{}
+	body, _ := json.Marshal(TranscodeJob{VideoID: 42, RetryCount: 3})
+	handleTranscodeDeadLetter(amqp.Delivery{Body: body, Acknowledger: ack}, zap.NewNop(), db)
+	require.Equal(t, 1, ack.acked)
+	var rec video.TranscodeDeadLetter
+	require.NoError(t, db.First(&rec).Error)
+	require.NotNil(t, rec.ProcessedAt)
 }
 
 func TestConsumeTranscodeDead_AcksAndCloses(t *testing.T) {
@@ -52,7 +69,7 @@ func TestConsumeTranscodeDead_AcksAndCloses(t *testing.T) {
 	close(msgs)
 
 	closer := &fakeCloseable{}
-	consumeTranscodeDead(context.Background(), closer, msgs, zap.NewNop())
+	consumeTranscodeDead(context.Background(), closer, msgs, zap.NewNop(), nil)
 	require.Equal(t, 1, ack.acked)
 	require.True(t, closer.closed)
 }
@@ -82,6 +99,41 @@ func TestStartTranscodeDeadConsumer_ReconnectsUntilCancel(t *testing.T) {
 	cancel()
 	<-done
 	require.GreaterOrEqual(t, sub.calls, 3)
+}
+
+func TestCleanupTranscodeDeadLetters_RemovesOnlyResolvedOld(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	old := time.Now().Add(-40 * 24 * time.Hour)
+	recent := time.Now().Add(-time.Hour)
+
+	tmp := t.TempDir()
+	processedRaw := filepath.Join(tmp, "processed.mp4")
+	requeuedRaw := filepath.Join(tmp, "requeued.mp4")
+	recentRaw := filepath.Join(tmp, "recent.mp4")
+	for _, p := range []string{processedRaw, requeuedRaw, recentRaw} {
+		require.NoError(t, os.WriteFile(p, []byte("media"), 0o644))
+	}
+	payload := func(raw string) string {
+		b, _ := json.Marshal(map[string]interface{}{"job": TranscodeJob{VideoID: 1, RawPath: raw}, "reason": "x"})
+		return string(b)
+	}
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{VideoID: 1, RetryCount: 1, Reason: "old processed", ProcessedAt: &old, PayloadJSON: payload(processedRaw)}).Error)
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{VideoID: 2, RetryCount: 1, Reason: "old requeued", RequeuedAt: &old, PayloadJSON: payload(requeuedRaw)}).Error)
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{VideoID: 3, RetryCount: 1, Reason: "recent processed", ProcessedAt: &recent, PayloadJSON: payload(recentRaw)}).Error)
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{VideoID: 4, RetryCount: 1, Reason: "pending"}).Error)
+
+	deleted := cleanupTranscodeDeadLetters(db, time.Now().Add(-30*24*time.Hour), zap.NewNop())
+	require.Equal(t, int64(2), deleted)
+	var left int64
+	require.NoError(t, db.Model(&video.TranscodeDeadLetter{}).Count(&left).Error)
+	require.Equal(t, int64(2), left)
+
+	_, err := os.Stat(processedRaw)
+	require.ErrorIs(t, err, os.ErrNotExist, "files of an old processed row are archived")
+	_, err = os.Stat(requeuedRaw)
+	require.NoError(t, err, "files of an old requeued row may still feed a successor job")
+	_, err = os.Stat(recentRaw)
+	require.NoError(t, err, "files of a recent row are not touched")
 }
 
 var errTestBrokerDown = &testBrokerError{}

--- a/internal/worker/transcode_pipeline_test.go
+++ b/internal/worker/transcode_pipeline_test.go
@@ -94,6 +94,13 @@ func newMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	return gormDB, mock
 }
 
+func expectProcessingVideo(mock sqlmock.Sqlmock, id uint64) {
+	mock.ExpectQuery("SELECT \\* FROM `videos` WHERE `videos`.`id` = .*").
+		WithArgs(id, 1).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "status"}).
+			AddRow(id, 1, "processing"))
+}
+
 func deliveryFor(job queue.TranscodeJob, ack *fakeAck) amqp.Delivery {
 	body, _ := json.Marshal(job)
 	return amqp.Delivery{Body: body, Acknowledger: ack}
@@ -126,6 +133,7 @@ func TestHandleDelivery_BadJSON(t *testing.T) {
 
 func TestHandleDelivery_OSSNotConfigured(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 1)
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	ack := &fakeAck{}
@@ -139,6 +147,7 @@ func TestHandleDelivery_OSSNotConfigured(t *testing.T) {
 
 func TestHandleDelivery_TranscodePermanent(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 5)
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	ack := &fakeAck{}
@@ -154,6 +163,7 @@ func TestHandleDelivery_TranscodePermanent(t *testing.T) {
 
 func TestHandleDelivery_TranscodeRetryableExhausted(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 6)
 	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
@@ -174,6 +184,7 @@ func TestHandleDelivery_TranscodeRetryableExhausted(t *testing.T) {
 
 func TestHandleDelivery_TranscodeRetryableRepublish(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 9)
 	oldDelay := transcodeRetryBaseDelay
 	transcodeRetryBaseDelay = time.Millisecond
 	defer func() { transcodeRetryBaseDelay = oldDelay }()
@@ -199,6 +210,7 @@ func TestHandleDelivery_TranscodeRetryableRepublish(t *testing.T) {
 
 func TestHandleDelivery_RepublishFailure(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 10)
 	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
@@ -221,6 +233,7 @@ func TestHandleDelivery_RepublishFailure(t *testing.T) {
 
 func TestHandleDelivery_UploadVideoFailsExhausted(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 11)
 	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectExec("UPDATE `videos` SET .*fail_reason.* WHERE id = .*").
@@ -273,6 +286,7 @@ func TestTruncate_RuneSafeUTF8(t *testing.T) {
 
 func TestHandleDelivery_SuccessDBError(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 12)
 	mock.ExpectExec("UPDATE `videos` SET .* WHERE id = .*").
 		WillReturnError(errors.New("db down"))
 	ack := &fakeAck{}
@@ -290,6 +304,7 @@ func TestHandleDelivery_SuccessDBError(t *testing.T) {
 
 func TestHandleDelivery_SuccessScreenshotPublish(t *testing.T) {
 	db, mock := newMockDB(t)
+	expectProcessingVideo(mock, 13)
 	// handleDelivery update
 	mock.ExpectExec("UPDATE .*videos.* SET .*").
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/migrations/00006_transcode_dead_letters_lifecycle.sql
+++ b/migrations/00006_transcode_dead_letters_lifecycle.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE `transcode_dead_letters`
+  ADD COLUMN `processed_at` datetime(3) DEFAULT NULL,
+  ADD COLUMN `requeued_at` datetime(3) DEFAULT NULL,
+  ADD COLUMN `requeued_count` bigint NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE `transcode_dead_letters`
+  DROP COLUMN `requeued_count`,
+  DROP COLUMN `requeued_at`,
+  DROP COLUMN `processed_at`;


### PR DESCRIPTION
Completes the transcode dead-letter lifecycle so failed jobs are observable and compensable.

Highlights:
- Admin list/requeue API for dead letters, with compensation: video is reset to processing, retry count is cleared, and if publishing fails both the video and the audit row are rolled back.
- Dead-letter paths now keep the original raw/cover media, so requeue can actually re-run ffmpeg. Requeue validates source existence first and returns 409/40023 when media was cleaned up.
- At-least-once redelivery guard: jobs whose video reached a terminal state are acked and skipped instead of re-transcoding.
- Versioned migration v23 creates transcode_dead_letters on existing databases (goose SQL already covered production).
- Retention archives resolved dead letters after 30 days and removes source files only when no successor job can reference them.
- Prometheus counters, alert rules and a Grafana dashboard for dead letters and requeues.
- Frontend admin page at /admin/transcode-dead-letters with status filter, pagination and per-row requeue.

Verification:
- go test -tags=integration ./...: 52 packages pass; handler 69.4%, worker 71.1%, service/video 68.4%.
- Frontend: lint, typecheck, 829 tests and production build pass.

Notes:
- deploy/monitoring is consumed via docker-compose bind mounts; the release bundle does not ship it yet, so the server needs a manual repo sync to load the new dashboard and rules.
- Base is main; no merge performed.