### PR TITLE
feat(worker): transcode reliability v3 — DLQ auto-retry race fix + async publisher confirm

### DIFF
--- a/internal/queue/queue_integration_test.go
+++ b/internal/queue/queue_integration_test.go
@@ -75,6 +75,35 @@ func TestPublishConfirmed_Integration(t *testing.T) {
 	}
 }
 
+func TestPublishConfirmed_Concurrent_Integration(t *testing.T) {
+	url := rabbitmqURL(t)
+	c, err := Dial(url)
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	const n = 8
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = c.PublishConfirmed(context.Background(), "", TranscodeQueue, true, amqp.Publishing{
+				DeliveryMode: amqp.Persistent,
+				Body:         []byte(fmt.Sprintf(`{"concurrent":%d}`, i)),
+			})
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent publish %d failed: %v", i, err)
+		}
+	}
+}
+
 func TestRetryQueueDeclaration_Integration(t *testing.T) {
 	url := rabbitmqURL(t)
 	c, err := Dial(url)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -3,6 +3,8 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -70,6 +72,18 @@ func (m *mockChannel) NotifyPublish(ch chan amqp.Confirmation) chan amqp.Confirm
 func (m *mockChannel) NotifyReturn(ch chan amqp.Return) chan amqp.Return {
 	m.returnCh = ch
 	return ch
+}
+
+// newConfirmClient builds a Client whose confirm reader is already running,
+// mirroring what initChannelLocked does after Dial.
+func newConfirmClient(t *testing.T, mc *mockChannel, confirms chan amqp.Confirmation, returns chan amqp.Return) *Client {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{ch: mc, confirms: confirms, returns: returns, gen: 1, ctx: ctx, cancel: cancel}
+	c.pending = make(map[publishKey]*publishWaiter)
+	c.startConfirmReader(1, confirms, returns)
+	t.Cleanup(cancel)
+	return c
 }
 
 // ---------- unit tests ----------
@@ -157,7 +171,7 @@ func TestPublishTranscode_Success(t *testing.T) {
 	confirms := make(chan amqp.Confirmation, 1)
 	returns := make(chan amqp.Return, 1)
 	confirms <- amqp.Confirmation{DeliveryTag: 1, Ack: true}
-	c := &Client{ch: mc, confirms: confirms, returns: returns}
+	c := newConfirmClient(t, mc, confirms, returns)
 	body := []byte(`{"video_id":123}`)
 	err := c.PublishTranscode(context.Background(), body)
 	if err != nil {
@@ -201,7 +215,7 @@ func TestPublishConfirmed_Success(t *testing.T) {
 	confirms := make(chan amqp.Confirmation, 1)
 	returns := make(chan amqp.Return, 1)
 	confirms <- amqp.Confirmation{DeliveryTag: 1, Ack: true}
-	c := &Client{ch: mc, confirms: confirms, returns: returns}
+	c := newConfirmClient(t, mc, confirms, returns)
 
 	err := c.PublishConfirmed(context.Background(), "", TranscodeDeadQueue, true, amqp.Publishing{
 		DeliveryMode: amqp.Persistent,
@@ -223,7 +237,7 @@ func TestPublishConfirmed_Nack(t *testing.T) {
 	confirms := make(chan amqp.Confirmation, 1)
 	returns := make(chan amqp.Return, 1)
 	confirms <- amqp.Confirmation{DeliveryTag: 1, Ack: false}
-	c := &Client{ch: mc, confirms: confirms, returns: returns}
+	c := newConfirmClient(t, mc, confirms, returns)
 
 	err := c.PublishConfirmed(context.Background(), "", TranscodeQueue, true, amqp.Publishing{Body: []byte("x")})
 	if err == nil {
@@ -235,8 +249,14 @@ func TestPublishConfirmed_Return(t *testing.T) {
 	mc := &mockChannel{t: t}
 	confirms := make(chan amqp.Confirmation, 1)
 	returns := make(chan amqp.Return, 1)
-	returns <- amqp.Return{ReplyCode: 404, ReplyText: "NOT_FOUND"}
-	c := &Client{ch: mc, confirms: confirms, returns: returns}
+	returns <- amqp.Return{
+		ReplyCode:  404,
+		ReplyText:  "NOT_FOUND",
+		Exchange:   "",
+		RoutingKey: TranscodeQueue,
+		Body:       []byte("x"),
+	}
+	c := newConfirmClient(t, mc, confirms, returns)
 
 	err := c.PublishConfirmed(context.Background(), "", TranscodeQueue, true, amqp.Publishing{Body: []byte("x")})
 	if err == nil {
@@ -248,7 +268,7 @@ func TestPublishConfirmed_ContextTimeout(t *testing.T) {
 	mc := &mockChannel{t: t}
 	confirms := make(chan amqp.Confirmation, 1)
 	returns := make(chan amqp.Return, 1)
-	c := &Client{ch: mc, confirms: confirms, returns: returns}
+	c := newConfirmClient(t, mc, confirms, returns)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
@@ -262,7 +282,7 @@ func TestPublishConfirmed_LateAckIgnoredByNextPublish(t *testing.T) {
 	mc := &mockChannel{t: t}
 	confirms := make(chan amqp.Confirmation, 2)
 	returns := make(chan amqp.Return, 1)
-	c := &Client{ch: mc, confirms: confirms, returns: returns}
+	c := newConfirmClient(t, mc, confirms, returns)
 
 	// First publish times out without a broker confirmation.
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
@@ -293,6 +313,82 @@ func TestPublishConfirmed_LateAckIgnoredByNextPublish(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("second publish did not complete after its own ack")
+	}
+}
+
+func TestPublishConfirmed_ConcurrentOutOfOrder(t *testing.T) {
+	mc := &mockChannel{t: t}
+	confirms := make(chan amqp.Confirmation, 2)
+	returns := make(chan amqp.Return, 1)
+	c := newConfirmClient(t, mc, confirms, returns)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs[i] = c.PublishConfirmed(context.Background(), "", TranscodeQueue, true,
+				amqp.Publishing{Body: []byte(fmt.Sprintf("m%d", i))})
+		}(i)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c.pendingMu.Lock()
+		n := len(c.pending)
+		c.pendingMu.Unlock()
+		if n == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("concurrent publishes did not register")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	// Deliver out of order: tag 2 first, then tag 1. Both must be attributed
+	// to their own publish instead of being rejected as tag mismatches.
+	confirms <- amqp.Confirmation{DeliveryTag: 2, Ack: true}
+	confirms <- amqp.Confirmation{DeliveryTag: 1, Ack: true}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("publish %d failed: %v", i, err)
+		}
+	}
+}
+
+func TestPublishConfirmed_ChannelCloseFailsPending(t *testing.T) {
+	mc := &mockChannel{t: t}
+	confirms := make(chan amqp.Confirmation)
+	returns := make(chan amqp.Return)
+	c := newConfirmClient(t, mc, confirms, returns)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- c.PublishConfirmed(context.Background(), "", TranscodeQueue, true,
+			amqp.Publishing{Body: []byte("x")})
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		c.pendingMu.Lock()
+		n := len(c.pending)
+		c.pendingMu.Unlock()
+		if n == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("publish did not register")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(confirms)
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error when the confirm channel closes")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending publish was not failed on channel close")
 	}
 }
 

--- a/internal/queue/rabbitmq.go
+++ b/internal/queue/rabbitmq.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
@@ -66,6 +67,26 @@ const publishConfirmTimeout = 5 * time.Second
 // variable for tests.
 var rabbitmqReconnectDelay = 3 * time.Second
 
+// publishKey identifies one in-flight publish by channel generation and
+// delivery tag. Generation separates confirmations of a replaced channel from
+// publishes on the current one (both channels restart their tags at 1).
+type publishKey struct {
+	gen uint64
+	seq uint64
+}
+
+// publishWaiter is one in-flight publish waiting for its broker confirmation.
+// The per-generation confirm reader resolves it; a confirmation that arrives
+// after the caller gave up finds no waiter and is ignored.
+type publishWaiter struct {
+	gen      uint64
+	seq      uint64
+	exchange string
+	key      string
+	body     []byte
+	done     chan error
+}
+
 // amqpChannel is the subset of *amqp.Channel needed by Client.
 type amqpChannel interface {
 	PublishWithContext(ctx context.Context, exchange, key string, mandatory, immediate bool, msg amqp.Publishing) error
@@ -90,6 +111,13 @@ type Client struct {
 	mu       sync.Mutex
 	confirms <-chan amqp.Confirmation
 	returns  <-chan amqp.Return
+
+	// pending maps delivery tags to in-flight publishes. It is guarded by
+	// pendingMu so a publish call only holds mu for the (fast) channel write,
+	// not for the whole broker round-trip.
+	pendingMu sync.Mutex
+	pending   map[publishKey]*publishWaiter
+	gen       uint64
 
 	closed        bool
 	reconnectWait time.Duration
@@ -195,7 +223,122 @@ func (c *Client) initChannelLocked() error {
 	c.ch = ch
 	c.confirms = confirms
 	c.returns = returns
+	c.gen++
+	c.startConfirmReader(c.gen, confirms, returns)
 	return nil
+}
+
+// startConfirmReader spawns the goroutine that resolves pending publishes of
+// one channel generation. The reader owns only pendingMu, so it never blocks
+// publishing.
+func (c *Client) startConfirmReader(gen uint64, confirms <-chan amqp.Confirmation, returns <-chan amqp.Return) {
+	go c.watchPublishConfirms(gen, confirms, returns)
+}
+
+// watchPublishConfirms resolves pending publishes as confirmations and
+// basic.returns arrive. It exits when the generation's channels close or the
+// client is cancelled, failing every still-pending publish of that generation
+// so no caller waits forever.
+func (c *Client) watchPublishConfirms(gen uint64, confirms <-chan amqp.Confirmation, returns <-chan amqp.Return) {
+	for {
+		select {
+		case <-c.ctx.Done():
+			c.failPendingGen(gen, fmt.Errorf("publish confirm: client closed"))
+			return
+		case conf, ok := <-confirms:
+			if !ok {
+				c.failPendingGen(gen, fmt.Errorf("publish confirm channel closed"))
+				return
+			}
+			c.deliverConfirm(gen, returns, conf)
+		case ret, ok := <-returns:
+			if !ok {
+				c.failPendingGen(gen, fmt.Errorf("publish return channel closed"))
+				return
+			}
+			c.deliverReturn(gen, ret)
+		}
+	}
+}
+
+func (c *Client) deliverConfirm(gen uint64, returns <-chan amqp.Return, conf amqp.Confirmation) {
+	key := publishKey{gen: gen, seq: conf.DeliveryTag}
+	c.pendingMu.Lock()
+	w := c.pending[key]
+	if w != nil {
+		delete(c.pending, key)
+	}
+	c.pendingMu.Unlock()
+	if w == nil {
+		// Late confirmation from an earlier timed-out publish (or an unknown
+		// tag); nothing is attributed to it.
+		return
+	}
+	if !conf.Ack {
+		w.done <- fmt.Errorf("publish nacked by broker")
+		return
+	}
+	// RabbitMQ sends basic.return before basic.ack for unroutable messages,
+	// so the waiter is normally already resolved by deliverReturn. Drain a
+	// matching return defensively in case ordering surprised us.
+	select {
+	case ret, ok := <-returns:
+		if ok && ret.Exchange == w.exchange && ret.RoutingKey == w.key && bytes.Equal(ret.Body, w.body) {
+			w.done <- fmt.Errorf("publish returned by broker: %s (code %d)", ret.ReplyText, ret.ReplyCode)
+			return
+		}
+	default:
+	}
+	w.done <- nil
+}
+
+func (c *Client) deliverReturn(gen uint64, ret amqp.Return) {
+	c.pendingMu.Lock()
+	var best *publishWaiter
+	for key, w := range c.pending {
+		if key.gen != gen || w.exchange != ret.Exchange || w.key != ret.RoutingKey || !bytes.Equal(w.body, ret.Body) {
+			continue
+		}
+		if best == nil || key.seq < best.seq {
+			best = w
+		}
+	}
+	if best != nil {
+		delete(c.pending, publishKey{gen: gen, seq: best.seq})
+	}
+	c.pendingMu.Unlock()
+	if best == nil {
+		return
+	}
+	best.done <- fmt.Errorf("publish returned by broker: %s (code %d)", ret.ReplyText, ret.ReplyCode)
+}
+
+func (c *Client) failPendingGen(gen uint64, err error) {
+	c.pendingMu.Lock()
+	var failed []*publishWaiter
+	for key, w := range c.pending {
+		if key.gen == gen {
+			delete(c.pending, key)
+			failed = append(failed, w)
+		}
+	}
+	c.pendingMu.Unlock()
+	for _, w := range failed {
+		w.done <- err
+	}
+}
+
+func (c *Client) failAllPending(err error) {
+	c.pendingMu.Lock()
+	failed := make([]*publishWaiter, 0, len(c.pending))
+	for key, w := range c.pending {
+		delete(c.pending, key)
+		failed = append(failed, w)
+	}
+	c.pendingMu.Unlock()
+	for _, w := range failed {
+		w.done <- err
+	}
 }
 
 // watchConnection waits for the underlying connection to die and rebuilds it
@@ -308,8 +451,9 @@ func (c *Client) Close() error {
 		_ = ch.Close()
 	}
 	if conn != nil {
-		return conn.Close()
+		_ = conn.Close()
 	}
+	c.failAllPending(fmt.Errorf("publish confirm: client closed"))
 	return nil
 }
 
@@ -331,57 +475,65 @@ func (c *Client) PublishTranscode(ctx context.Context, body []byte) error {
 // misattributed to the next call.
 func (c *Client) PublishConfirmed(ctx context.Context, exchange, key string, mandatory bool, msg amqp.Publishing) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.closed {
+		c.mu.Unlock()
 		return fmt.Errorf("client closed")
 	}
 	if c.ch == nil || c.confirms == nil {
+		c.mu.Unlock()
 		return fmt.Errorf("publisher confirm not enabled")
 	}
 	seq := c.ch.GetNextPublishSeqNo()
 	if err := c.ch.PublishWithContext(ctx, exchange, key, mandatory, false, msg); err != nil {
+		c.mu.Unlock()
 		return err
 	}
+	w := &publishWaiter{
+		gen:      c.gen,
+		seq:      seq,
+		exchange: exchange,
+		key:      key,
+		body:     msg.Body,
+		done:     make(chan error, 1),
+	}
+	c.pendingMu.Lock()
+	if c.pending == nil {
+		c.pending = make(map[publishKey]*publishWaiter)
+	}
+	c.pending[publishKey{gen: w.gen, seq: seq}] = w
+	c.pendingMu.Unlock()
+	c.mu.Unlock()
+	return c.waitConfirm(ctx, w)
+}
+
+// waitConfirm blocks until the broker confirms this publish, the caller's
+// context expires, or the 5s confirm window elapses. Timeout/cancel removes
+// the waiter so a late confirmation is ignored instead of misattributed.
+func (c *Client) waitConfirm(ctx context.Context, w *publishWaiter) error {
 	timeout := time.NewTimer(publishConfirmTimeout)
 	defer timeout.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("publish confirm: %w", ctx.Err())
-		case ret, ok := <-c.returns:
-			if ok {
-				return fmt.Errorf("publish returned by broker: %s (code %d)", ret.ReplyText, ret.ReplyCode)
-			}
-			return fmt.Errorf("publish return channel closed")
-		case conf, ok := <-c.confirms:
-			if !ok {
-				return fmt.Errorf("publish confirm channel closed")
-			}
-			if conf.DeliveryTag < seq {
-				// Late confirmation from an earlier timed-out publish;
-				// ignore it and keep waiting for ours.
-				continue
-			}
-			if conf.DeliveryTag > seq {
-				return fmt.Errorf("publish confirm tag mismatch: got %d, want %d", conf.DeliveryTag, seq)
-			}
-			if !conf.Ack {
-				return fmt.Errorf("publish nacked by broker")
-			}
-			// RabbitMQ sends basic.return before basic.ack for unroutable
-			// messages; drain a return that is already buffered.
-			select {
-			case ret, ok := <-c.returns:
-				if ok {
-					return fmt.Errorf("publish returned by broker: %s (code %d)", ret.ReplyText, ret.ReplyCode)
-				}
-			default:
-			}
-			return nil
-		case <-timeout.C:
-			return fmt.Errorf("publish confirm timeout after %s", publishConfirmTimeout)
+	select {
+	case <-ctx.Done():
+		c.dropPending(w)
+		return fmt.Errorf("publish confirm: %w", ctx.Err())
+	case err := <-w.done:
+		if err != nil {
+			return err
 		}
+		return nil
+	case <-timeout.C:
+		c.dropPending(w)
+		return fmt.Errorf("publish confirm timeout after %s", publishConfirmTimeout)
 	}
+}
+
+func (c *Client) dropPending(w *publishWaiter) {
+	key := publishKey{gen: w.gen, seq: w.seq}
+	c.pendingMu.Lock()
+	if c.pending[key] == w {
+		delete(c.pending, key)
+	}
+	c.pendingMu.Unlock()
 }
 
 // connSnapshot returns the current connection under lock, or nil when closed.

--- a/internal/worker/dead_letter_auto_retry.go
+++ b/internal/worker/dead_letter_auto_retry.go
@@ -41,10 +41,15 @@ var autoRetryNonRetryableKeywords = []string{
 	"OSS 未配置", "未配置", "not configured", "configuration",
 }
 
-// errAutoRetrySkip rolls back the per-row transaction when the video is not
-// in a retryable state (deleted or already terminal), without counting it as
-// an error.
-var errAutoRetrySkip = errors.New("auto retry skip: video not retryable")
+// errAutoRetrySkip rolls back the per-row transaction when another replay is
+// already in flight (video is processing); the row is left pending so the
+// in-flight job's outcome decides its fate.
+var errAutoRetrySkip = errors.New("auto retry skip: replay already in flight")
+
+// errAutoRetryResolve rolls back the per-row transaction when the video is
+// deleted or in a terminal state; the row is then marked processed so it can
+// be archived instead of dangling as pending forever.
+var errAutoRetryResolve = errors.New("auto retry resolve: video not retryable")
 
 // StartTranscodeDeadLetterAutoRetry periodically requeues unresolved dead
 // letters whose reason is transient. Each row gets a bounded number of auto
@@ -74,16 +79,29 @@ func StartTranscodeDeadLetterAutoRetry(ctx context.Context, db *gorm.DB, lg *zap
 func autoRetryDeadLettersOnce(ctx context.Context, db *gorm.DB, lg *zap.Logger) (int, error) {
 	var rows []video.TranscodeDeadLetter
 	if err := db.WithContext(ctx).
-		Where("archived_at IS NULL AND processed_at IS NULL AND requeued_at IS NULL AND auto_retry_count < ?", deadLetterAutoRetryMax).
+		Where("archived_at IS NULL AND processed_at IS NULL AND requeued_at IS NULL").
 		Order("id ASC").
 		Limit(deadLetterAutoRetryBatch).
 		Find(&rows).Error; err != nil {
 		return 0, err
 	}
 	requeued := 0
+	resolve := func(rowID uint64, why string) {
+		if err := resolveTranscodeDeadLetter(db.WithContext(ctx), rowID); err != nil {
+			lg.Warn("resolve transcode dead letter",
+				zap.Uint64("dead_letter_id", rowID),
+				zap.String("why", why),
+				zap.Error(err))
+		}
+	}
 	for i := range rows {
 		row := rows[i]
 		if !autoRetryableReason(row.Reason) {
+			resolve(row.ID, "not transient")
+			continue
+		}
+		if row.AutoRetryCount >= deadLetterAutoRetryMax {
+			resolve(row.ID, "per-row budget exhausted")
 			continue
 		}
 		backoff := deadLetterAutoRetryBase << row.AutoRetryCount
@@ -97,6 +115,7 @@ func autoRetryDeadLettersOnce(ctx context.Context, db *gorm.DB, lg *zap.Logger) 
 			Job queue.TranscodeJob `json:"job"`
 		}
 		if err := json.Unmarshal([]byte(row.PayloadJSON), &payload); err != nil || payload.Job.VideoID == 0 {
+			resolve(row.ID, "invalid payload")
 			continue
 		}
 		// Lifetime bound: sum auto retries across all un-archived dead-letter
@@ -111,6 +130,7 @@ func autoRetryDeadLettersOnce(ctx context.Context, db *gorm.DB, lg *zap.Logger) 
 			continue
 		}
 		if totalAutoRetries >= deadLetterAutoRetryTotalMax {
+			resolve(row.ID, "lifetime budget exhausted")
 			continue
 		}
 		job := payload.Job
@@ -128,14 +148,20 @@ func autoRetryDeadLettersOnce(ctx context.Context, db *gorm.DB, lg *zap.Logger) 
 			// the transaction so the state we validated is the state we update.
 			var v video.Video
 			if err := tx.WithContext(ctx).First(&v, job.VideoID).Error; err != nil {
-				return errAutoRetrySkip
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return errAutoRetryResolve
+				}
+				return err
 			}
 			// Only failed videos are retryable. processing means a replay (or
 			// a normal job) is already in flight; scheduling again here would
 			// double-transcode the same video in the minute-level window
-			// before the dead letter is marked processed.
+			// before the in-flight job resolves this row.
 			if v.Status != video.StatusFailed {
-				return errAutoRetrySkip
+				if v.Status == video.StatusProcessing {
+					return errAutoRetrySkip
+				}
+				return errAutoRetryResolve
 			}
 			if err := tx.WithContext(ctx).Create(&video.TranscodeOutbox{
 				JobID:   job.JobID,
@@ -172,6 +198,10 @@ func autoRetryDeadLettersOnce(ctx context.Context, db *gorm.DB, lg *zap.Logger) 
 			}).Error
 		})
 		if errors.Is(txErr, errAutoRetrySkip) {
+			continue
+		}
+		if errors.Is(txErr, errAutoRetryResolve) {
+			resolve(row.ID, "video terminal or missing")
 			continue
 		}
 		if txErr != nil {

--- a/internal/worker/dead_letter_auto_retry_test.go
+++ b/internal/worker/dead_letter_auto_retry_test.go
@@ -61,6 +61,7 @@ func TestAutoRetryDeadLettersOnce_RequeuesTransient(t *testing.T) {
 	require.NoError(t, db.First(&row).Error)
 	require.Equal(t, 1, row.AutoRetryCount)
 	require.NotNil(t, row.LastAutoRetryAt)
+	require.Nil(t, row.ProcessedAt, "a scheduled replay leaves the row pending until its outcome is known")
 	var v video.Video
 	require.NoError(t, db.First(&v, 80).Error)
 	require.Equal(t, video.StatusProcessing, v.Status)
@@ -83,6 +84,10 @@ func TestAutoRetryDeadLettersOnce_SkipsPermanent(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, n)
 	require.Zero(t, countOutbox(t, db))
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.First(&row).Error)
+	require.NotNil(t, row.ProcessedAt, "permanent reasons must be resolved so retention can archive the row")
+	require.Zero(t, row.AutoRetryCount)
 }
 
 func TestAutoRetryDeadLettersOnce_RespectsMaxAndBackoff(t *testing.T) {
@@ -109,6 +114,12 @@ func TestAutoRetryDeadLettersOnce_RespectsMaxAndBackoff(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, n, "maxed-out and backoff-pending rows must not be requeued")
 	require.Zero(t, countOutbox(t, db))
+	var maxed video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 82).First(&maxed).Error)
+	require.NotNil(t, maxed.ProcessedAt, "a maxed-out row is terminal and must be resolved")
+	var backoff video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 83).First(&backoff).Error)
+	require.Nil(t, backoff.ProcessedAt, "a row inside its backoff window stays pending for the next scan")
 }
 
 func TestAutoRetryDeadLettersOnce_SkipsTerminalOrMissingVideo(t *testing.T) {
@@ -134,6 +145,10 @@ func TestAutoRetryDeadLettersOnce_SkipsTerminalOrMissingVideo(t *testing.T) {
 	var row video.TranscodeDeadLetter
 	require.NoError(t, db.Where("video_id = ?", 84).First(&row).Error)
 	require.Zero(t, row.AutoRetryCount, "skipped rows must not consume retry budget")
+	require.NotNil(t, row.ProcessedAt, "a terminal video resolves the row so it can archive")
+	var missing video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 85).First(&missing).Error)
+	require.NotNil(t, missing.ProcessedAt, "a missing video resolves the row so it can archive")
 }
 
 func TestAutoRetryDeadLettersOnce_SkipsProcessingVideo(t *testing.T) {
@@ -152,6 +167,10 @@ func TestAutoRetryDeadLettersOnce_SkipsProcessingVideo(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, n)
 	require.Zero(t, countOutbox(t, db))
+	var row video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 86).First(&row).Error)
+	require.Nil(t, row.ProcessedAt, "an in-flight replay leaves the row pending; its outcome resolves it")
+	require.Zero(t, row.AutoRetryCount)
 }
 
 func TestAutoRetryDeadLettersOnce_LifetimeBudgetStopsNewRows(t *testing.T) {
@@ -178,6 +197,12 @@ func TestAutoRetryDeadLettersOnce_LifetimeBudgetStopsNewRows(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, n, "lifetime budget exhausted: fresh rows must not restart retries")
 	require.Zero(t, countOutbox(t, db))
+	var rows []video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 87).Order("id ASC").Find(&rows).Error)
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		require.NotNil(t, r.ProcessedAt, "rows whose lifetime budget is exhausted must be resolved")
+	}
 }
 
 func TestAutoRetryDeadLettersOnce_LifetimeBudgetStillAllowsWithinLimit(t *testing.T) {

--- a/internal/worker/transcode.go
+++ b/internal/worker/transcode.go
@@ -572,6 +572,16 @@ func deadLetterTranscode(ctx context.Context, db *gorm.DB, pubCh transcodePublis
 	}
 	if err := db.Create(&rec).Error; err != nil {
 		lg.Warn("record transcode dead letter", zap.Uint64("video_id", job.VideoID), zap.Error(err))
+		return
+	}
+	// Every failed replay creates a NEW dead-letter row. Close all older
+	// unresolved rows of the same video: the current row is the only one the
+	// auto-retry loop (or an operator) should act on. Without this, superseded
+	// rows stay pending forever and can never be archived.
+	if err := db.Model(&video.TranscodeDeadLetter{}).
+		Where("video_id = ? AND id <> ? AND processed_at IS NULL AND requeued_at IS NULL AND archived_at IS NULL", job.VideoID, rec.ID).
+		Update("processed_at", time.Now()).Error; err != nil {
+		lg.Warn("close superseded transcode dead letters", zap.Uint64("video_id", job.VideoID), zap.Error(err))
 	}
 }
 
@@ -663,9 +673,12 @@ func consumeTranscodeDead(ctx context.Context, ch interface{ Close() error }, ms
 	}
 }
 
-// handleTranscodeDeadLetter marks the matching audit row processed and only
-// then acks the message. A DB failure leaves the message unacked so it is
-// redelivered and retried instead of being observably lost.
+// handleTranscodeDeadLetter resolves the matching audit row and only then
+// acks the message. Rows whose reason is transient are deliberately left
+// pending (processed_at IS NULL) so the auto-retry loop can see and act on
+// them; the loop or a superseding dead letter closes them later. A DB
+// failure leaves the message unacked so it is redelivered and retried
+// instead of being observably lost.
 func handleTranscodeDeadLetter(d amqp.Delivery, lg *zap.Logger, db *gorm.DB) {
 	var job TranscodeJob
 	_ = json.Unmarshal(d.Body, &job)
@@ -677,17 +690,40 @@ func handleTranscodeDeadLetter(d amqp.Delivery, lg *zap.Logger, db *gorm.DB) {
 		zap.Int("retry_count", job.RetryCount),
 	)
 	if db != nil {
-		if err := db.Model(&video.TranscodeDeadLetter{}).
-			Where("video_id = ? AND retry_count = ? AND processed_at IS NULL", job.VideoID, job.RetryCount).
+		var row video.TranscodeDeadLetter
+		err := db.Where("video_id = ? AND retry_count = ? AND processed_at IS NULL AND archived_at IS NULL", job.VideoID, job.RetryCount).
 			Order("id DESC").
 			Limit(1).
-			Update("processed_at", time.Now()).Error; err != nil {
+			First(&row).Error
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				lg.Warn("load transcode dead letter", zap.Uint64("video_id", job.VideoID), zap.Error(err))
+				_ = d.Nack(false, true)
+				return
+			}
+		} else if autoRetryableReason(row.Reason) {
+			// Leave the row pending: the auto-retry loop owns transient
+			// failures and must still be able to see them (processed_at IS
+			// NULL). The loop resolves the row when it schedules a replay or
+			// when the row turns terminal.
+			_ = d.Ack(false)
+			return
+		} else if err := db.Model(&row).Update("processed_at", time.Now()).Error; err != nil {
 			lg.Warn("mark transcode dead letter processed", zap.Uint64("video_id", job.VideoID), zap.Error(err))
 			_ = d.Nack(false, true)
 			return
 		}
 	}
 	_ = d.Ack(false)
+}
+
+// resolveTranscodeDeadLetter closes a still-pending dead letter so retention
+// can eventually archive it. It is a conditional update: a row that was
+// manually requeued (requeued_at) or already resolved is left untouched.
+func resolveTranscodeDeadLetter(db *gorm.DB, id uint64) error {
+	return db.Model(&video.TranscodeDeadLetter{}).
+		Where("id = ? AND processed_at IS NULL AND requeued_at IS NULL AND archived_at IS NULL", id).
+		Update("processed_at", time.Now()).Error
 }
 
 const (

--- a/internal/worker/transcode_dead_consumer_test.go
+++ b/internal/worker/transcode_dead_consumer_test.go
@@ -91,6 +91,20 @@ func TestHandleTranscodeDeadLetter_MarksProcessed(t *testing.T) {
 	require.NotNil(t, rec.ProcessedAt)
 }
 
+func TestHandleTranscodeDeadLetter_LeavesTransientPending(t *testing.T) {
+	db := newBehavioralWorkerDB(t)
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{
+		VideoID: 43, RetryCount: 3, Reason: "oss upload failed", PayloadJSON: "{}",
+	}).Error)
+	ack := &fakeAck{}
+	body, _ := json.Marshal(TranscodeJob{VideoID: 43, RetryCount: 3})
+	handleTranscodeDeadLetter(amqp.Delivery{Body: body, Acknowledger: ack}, zap.NewNop(), db)
+	require.Equal(t, 1, ack.acked)
+	var rec video.TranscodeDeadLetter
+	require.NoError(t, db.First(&rec).Error)
+	require.Nil(t, rec.ProcessedAt, "transient rows must stay visible to the auto-retry loop")
+}
+
 func TestConsumeTranscodeDead_AcksAndCloses(t *testing.T) {
 	ack := &fakeAck{}
 	body, _ := json.Marshal(TranscodeJob{VideoID: 7, RetryCount: 2})

--- a/internal/worker/transcode_pipeline_test.go
+++ b/internal/worker/transcode_pipeline_test.go
@@ -245,6 +245,8 @@ func TestHandleDelivery_TranscodeRetryableExhausted(t *testing.T) {
 	expectProcessingVideo(mock, 6)
 	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE `transcode_dead_letters`").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectFailVideo(mock, 6)
 	ack := &fakeAck{}
 	job := queue.TranscodeJob{VideoID: 6, RawPath: "/tmp/r.mp4", RetryCount: 3}
@@ -288,6 +290,8 @@ func TestHandleDelivery_RepublishFailure(t *testing.T) {
 	expectProcessingVideo(mock, 10)
 	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE `transcode_dead_letters`").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectFailVideo(mock, 10)
 
 	ack := &fakeAck{}
@@ -307,6 +311,8 @@ func TestHandleDelivery_UploadVideoFailsExhausted(t *testing.T) {
 	expectProcessingVideo(mock, 11)
 	mock.ExpectExec("INSERT INTO `transcode_dead_letters`").
 		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("UPDATE `transcode_dead_letters`").
+		WillReturnResult(sqlmock.NewResult(0, 0))
 	expectFailVideo(mock, 11)
 	ack := &fakeAck{}
 	job := queue.TranscodeJob{VideoID: 11, RawPath: "/tmp/r.mp4", CoverPath: "/tmp/c.jpg", RetryCount: 3}
@@ -324,6 +330,11 @@ func TestDeadLetterTranscode_PersistsAndPublishes(t *testing.T) {
 	db := newBehavioralWorkerDB(t)
 	pub := &fakePublisher{}
 	job := queue.TranscodeJob{VideoID: 7, RawPath: "/tmp/r.mp4", RetryCount: 3}
+	// An older unresolved row for the same video exists: it must be closed as
+	// superseded, otherwise pending rows accumulate forever.
+	require.NoError(t, db.Create(&video.TranscodeDeadLetter{
+		VideoID: 7, RetryCount: 2, Reason: "oss down", PayloadJSON: "{}",
+	}).Error)
 	deadLetterTranscode(context.Background(), db, pub, zap.NewNop(), job, "oss down")
 
 	require.Len(t, pub.published, 1)
@@ -332,11 +343,14 @@ func TestDeadLetterTranscode_PersistsAndPublishes(t *testing.T) {
 	require.NoError(t, json.Unmarshal(pub.published[0].Body, &dead))
 	require.Equal(t, uint64(7), dead.VideoID)
 
-	var rec video.TranscodeDeadLetter
-	require.NoError(t, db.Where("video_id = ?", 7).First(&rec).Error)
-	require.Equal(t, "oss down", rec.Reason)
-	require.Equal(t, 3, rec.RetryCount)
-	require.Contains(t, rec.PayloadJSON, "oss down")
+	var recs []video.TranscodeDeadLetter
+	require.NoError(t, db.Where("video_id = ?", 7).Order("id ASC").Find(&recs).Error)
+	require.Len(t, recs, 2)
+	require.NotNil(t, recs[0].ProcessedAt, "superseded row must be closed")
+	require.Nil(t, recs[1].ProcessedAt, "the current dead letter stays pending for auto retry")
+	require.Equal(t, "oss down", recs[1].Reason)
+	require.Equal(t, 3, recs[1].RetryCount)
+	require.Contains(t, recs[1].PayloadJSON, "oss down")
 }
 
 func TestTruncate_RuneSafeUTF8(t *testing.T) {


### PR DESCRIPTION
## Summary
Two reliability fixes on the transcode pipeline, each backed by behavioral tests.

## 1. fix(worker): DLQ auto-retry race with dead-letter consumer
The dead-letter consumer unconditionally set `processed_at` on every audit row,
while the auto-retry loop only scans `processed_at IS NULL` rows. With a healthy
consumer, auto-retry could effectively never trigger, and superseded rows stayed
pending forever (never archivable).

- Dead-letter consumer now leaves transient-reason rows pending and only marks
  non-transient rows processed before Ack.
- Auto-retry scans all unresolved rows and explicitly resolves terminal ones
  (permanent reason, per-row/lifetime budget exhausted, invalid payload, video
  terminal or missing). In-flight (`processing`) and backoff rows stay pending.
- Creating a new dead-letter row closes older unresolved rows of the same video.
- Every row now converges to `pending → processed/requeued → archived`;
  manual requeue remains the final fallback.

## 2. feat(queue): decouple publisher confirm wait from the publish lock
`PublishConfirmed` previously held `Client.mu` for the whole publish + broker
confirm round-trip, serializing all publishes behind one network wait.

- Publish writes stay serialized (AMQP channel is not thread-safe), but the
  confirm wait is decoupled: each publish registers a `(channel generation,
  delivery tag)` waiter and releases the lock immediately.
- A per-generation confirm reader dispatches ack/nack by tag and matches
  `basic.return` by exchange / routing-key / body; late confirmations find no
  waiter and are ignored.
- Channel/client close fails all in-flight publishes of that generation instead
  of hanging callers; reconnect bumps the generation so old/new pending maps
  never collide.

## Tests
- Worker: transient rows stay pending after dead-letter consumption, new rows
  close superseded rows, terminal/budget-exhausted rows are resolved,
  in-flight/backoff rows stay pending; sqlmock retry-exhaustion paths updated.
- Queue: success / nack / return / timeout / late-ack isolation / concurrent
  out-of-order confirmations / confirm-channel-close failing in-flight
  publishes; `go test -race` clean.
- New real-broker integration test `TestPublishConfirmed_Concurrent_Integration`
  runs on CI with the RabbitMQ service.

## Notes
- No DB migration required.
- Local verification: worker tests, queue publish tests, `go build ./...`,
  `go vet`, and `go test -race` all green.