### PR TITLE
feat(comment): real server-side pagination for comments

### DIFF
--- a/cakecake-vue/cakecake-web/src/__tests__/api/cakecake.spec.ts
+++ b/cakecake-vue/cakecake-web/src/__tests__/api/cakecake.spec.ts
@@ -42,7 +42,13 @@ describe("mbListVideos",function(){it("GET /videos with params",async function()
 describe("mbListComments",function(){it("GET /videos/:id/comments",async function(){
   mockHttp.get.mockResolvedValue(ok({ items:[], comments_closed:false }));
   mb.mbListComments(42);
-  expect(mockHttp.get).toHaveBeenCalledWith("/api/v1/videos/42/comments");
+  expect(mockHttp.get).toHaveBeenCalledWith("/api/v1/videos/42/comments", {
+    params: undefined
+  });
+  mb.mbListComments(42, { page: 2, page_size: 20, sort: "time" });
+  expect(mockHttp.get).toHaveBeenCalledWith("/api/v1/videos/42/comments", {
+    params: { page: 2, page_size: 20, sort: "time" }
+  });
 });});
 
 describe("mbToggleVideoLike",function(){it("POST /videos/:id/like",async function(){

--- a/cakecake-vue/cakecake-web/src/api/cakecake.ts
+++ b/cakecake-vue/cakecake-web/src/api/cakecake.ts
@@ -970,14 +970,27 @@ export async function mbPostDanmaku(
   return unwrap(r);
 }
 
-export async function mbListComments(
-  videoId: number
-): Promise<{
+export interface CommentListQuery {
+  page?: number;
+  page_size?: number;
+  sort?: "hot" | "time";
+}
+
+export interface CommentListResult {
   items: CommentItem[];
   comments_closed?: boolean;
   comments_curated?: boolean;
-}> {
-  const r = await http.get(`/api/v1/videos/${videoId}/comments`);
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+}
+
+export async function mbListComments(
+  videoId: number,
+  params?: CommentListQuery
+): Promise<CommentListResult> {
+  const r = await http.get(`/api/v1/videos/${videoId}/comments`, { params });
   return unwrap(r);
 }
 
@@ -2125,13 +2138,10 @@ export async function mbListUserArticleFavorites(
 }
 
 export async function mbListArticleComments(
-  articleId: number
-): Promise<{
-  items: CommentItem[];
-  comments_closed?: boolean;
-  comments_curated?: boolean;
-}> {
-  const r = await http.get(`/api/v1/articles/${articleId}/comments`);
+  articleId: number,
+  params?: CommentListQuery
+): Promise<CommentListResult> {
+  const r = await http.get(`/api/v1/articles/${articleId}/comments`, { params });
   return unwrap(r);
 }
 
@@ -2225,13 +2235,12 @@ export async function mbGetUserDynamic(id: number): Promise<UserDynamicDetail> {
 }
 
 export async function mbListDynamicComments(
-  dynamicId: number
-): Promise<{
-  items: CommentItem[];
-  comments_closed?: boolean;
-  comments_curated?: boolean;
-}> {
-  const r = await http.get(`/api/v1/user-dynamics/${dynamicId}/comments`);
+  dynamicId: number,
+  params?: CommentListQuery
+): Promise<CommentListResult> {
+  const r = await http.get(`/api/v1/user-dynamics/${dynamicId}/comments`, {
+    params
+  });
   return unwrap(r);
 }
 

--- a/cakecake-vue/cakecake-web/src/components/cakecake/MbDynVideoCommentPanel.vue
+++ b/cakecake-vue/cakecake-web/src/components/cakecake/MbDynVideoCommentPanel.vue
@@ -278,6 +278,8 @@
           :article-author-id="isArticle ? articleAuthorId : 0"
           :dynamic-author-id="isDynamic ? dynamicAuthorId : 0"
           :comment-sort="commentSort"
+          :page="commentCurrentPage"
+          :page-size="COMMENT_PAGE_SIZE"
           :initial-comments-curated="commentsCurated"
           :initial-comments-closed="commentsClosed"
           @counts="onLiveCounts"
@@ -565,10 +567,14 @@ export default {
       }
       return String(v);
     },
-    applyCommentTotal(n) {
+    applyCommentTotal(n, totalPages) {
       const v = Number(n) || 0;
       this.commentTotal = v;
-      this.commentTotalPages = Math.max(1, Math.ceil(v / COMMENT_PAGE_SIZE));
+      const pages = Number(totalPages);
+      this.commentTotalPages =
+        Number.isFinite(pages) && pages >= 1
+          ? Math.floor(pages)
+          : Math.max(1, Math.ceil(v / COMMENT_PAGE_SIZE));
       if (this.commentCurrentPage > this.commentTotalPages) {
         this.commentCurrentPage = this.commentTotalPages;
       }
@@ -623,9 +629,9 @@ export default {
       }
       return Promise.resolve();
     },
-    onLiveCounts(n) {
-      const count = Number(n) || 0;
-      this.applyCommentTotal(count);
+    onLiveCounts(total, totalPages) {
+      const count = Number(total) || 0;
+      this.applyCommentTotal(count, totalPages);
       this.emitPatch({ comment_count: count });
       this.$emit("counts", count);
     },

--- a/cakecake-vue/cakecake-web/src/components/comment/VdCommentPanelMb.vue
+++ b/cakecake-vue/cakecake-web/src/components/comment/VdCommentPanelMb.vue
@@ -145,6 +145,8 @@
             :article-author-id="articleId ? authorId : null"
             :dynamic-author-id="dynamicId ? authorId : null"
             :comment-sort="commentSort"
+            :page="commentCurrentPage"
+            :page-size="commentPageSize"
             :highlight-comment-id="highlightCommentId"
             :initial-comments-curated="commentsCurated"
             :initial-comments-closed="commentsClosed"
@@ -230,6 +232,7 @@ export default {
       MB_COMMENT_CURATED_LABEL,
       commentTotal: 0,
       commentTotalPages: 1,
+      commentPageSize: 20,
       commentCurrentPage: 1,
       commentPageJumpDraft: "1",
       commentDraft: "",
@@ -324,19 +327,23 @@ export default {
     }
   },
   methods: {
-    applyCommentTotal(n) {
+    applyCommentTotal(n, totalPages) {
       const v = Number(n);
       if (!Number.isFinite(v) || v < 0) return;
       this.commentTotal = v;
-      this.commentTotalPages = Math.max(1, Math.ceil(v / 20));
+      const pages = Number(totalPages);
+      this.commentTotalPages =
+        Number.isFinite(pages) && pages >= 1
+          ? Math.floor(pages)
+          : Math.max(1, Math.ceil(v / 20));
       if (this.commentCurrentPage > this.commentTotalPages) {
         this.commentCurrentPage = this.commentTotalPages;
       }
       this.commentPageJumpDraft = String(this.commentCurrentPage);
     },
-    onCommentCounts(n) {
-      this.applyCommentTotal(n);
-      this.$emit("counts", n);
+    onCommentCounts(total, totalPages) {
+      this.applyCommentTotal(total, totalPages);
+      this.$emit("counts", total, totalPages);
     },
     setCommentPage(n) {
       const t = Math.max(

--- a/cakecake-vue/cakecake-web/src/pages/cakecake/CakecakeCommentsLive.vue
+++ b/cakecake-vue/cakecake-web/src/pages/cakecake/CakecakeCommentsLive.vue
@@ -636,12 +636,18 @@ export default {
     /** 父级已知精选状态时可传入，避免首屏闪烁 */
     initialCommentsCurated: { type: Boolean, default: null },
     /** 父级已知关闭评论时可传入，避免请求评论列表报 403 */
-    initialCommentsClosed: { type: Boolean, default: null }
+    initialCommentsClosed: { type: Boolean, default: null },
+    /** 根评论分页：> 0 时按页切片展示（列表仍一次加载，适配中小评论量） */
+    page: { type: Number, default: 0 },
+    /** 每页根评论条数 */
+    pageSize: { type: Number, default: 20 }
   },
   emits: ["counts"],
   data() {
     return {
       items: [],
+      total: 0,
+      totalPages: 1,
       draft: "",
       loading: false,
       posting: false,
@@ -824,6 +830,9 @@ export default {
     dynamicId() {
       this.onTargetChange();
     },
+    page() {
+      this.load({ soft: true, preserveExpand: true });
+    },
     "$store.state.login.signIn"(v) {
       if (String(v) === "1" && getAccessToken()) {
         this.load({ soft: true, preserveExpand: true });
@@ -831,6 +840,7 @@ export default {
     },
     commentSort() {
       this.recomputeRootDisplayOrder();
+      this.load({ soft: true, preserveExpand: true });
     },
     highlightCommentId: {
       handler() {
@@ -1112,9 +1122,15 @@ export default {
         this.loading = true;
       }
       try {
+        const page = this.page > 0 ? this.page : 1;
+        const params = {
+          page,
+          page_size: this.pageSize,
+          sort: this.commentSort
+        };
         let res;
         if (this.isDynamic) {
-          res = await mbListDynamicComments(this.dynamicId);
+          res = await mbListDynamicComments(this.dynamicId, params);
           this.commentsClosedLocal = !!res.comments_closed;
           if (
             this.initialCommentsCurated === null ||
@@ -1123,7 +1139,7 @@ export default {
             this.commentsCuratedLocal = !!res.comments_curated;
           }
         } else if (this.isArticle) {
-          res = await mbListArticleComments(this.articleId);
+          res = await mbListArticleComments(this.articleId, params);
           this.commentsClosedLocal = !!res.comments_closed;
           if (
             this.initialCommentsCurated === null ||
@@ -1132,7 +1148,7 @@ export default {
             this.commentsCuratedLocal = !!res.comments_curated;
           }
         } else {
-          res = await mbListComments(this.videoId);
+          res = await mbListComments(this.videoId, params);
           this.commentsClosedLocal = !!res.comments_closed;
           if (
             this.initialCommentsCurated === null ||
@@ -1142,11 +1158,18 @@ export default {
           }
         }
         this.items = res.items || [];
+        const total = Number(res.total ?? this.items.length);
+        this.total = Number.isFinite(total) ? total : this.items.length;
+        this.totalPages = Math.max(
+          1,
+          Number(res.total_pages) ||
+            Math.ceil(this.total / Math.max(1, this.pageSize))
+        );
         if (!soft && !opts.preserveExpand) {
           this.expandedReplyThreads = {};
         }
         this.recomputeRootDisplayOrder();
-        this.$emit("counts", this.items.length);
+        this.$emit("counts", this.total, this.totalPages);
       } catch (e) {
         const apiCode =
           e && typeof e.cakecakeApiCode === "number" ? e.cakecakeApiCode : 0;
@@ -1154,7 +1177,7 @@ export default {
           this.commentsClosedLocal = true;
           this.items = [];
           this.loadError = "";
-          this.$emit("counts", 0);
+          this.$emit("counts", 0, 1);
           return;
         }
         this.loadError = (e && e.message) || "加载评论失败";

--- a/cakecake-vue/cakecake-web/src/pages/video/video.vue
+++ b/cakecake-vue/cakecake-web/src/pages/video/video.vue
@@ -596,10 +596,13 @@
                     </button>
                   </template>
                 </div>
-                <div class="vd-cmt-page-top vd-cmt-page-top--links">
-                  <span class="vd-page-info">共{{ commentTotalPages }}页</span>
+                <div
+                  v-if="isMb"
+                  class="vd-cmt-page-top vd-cmt-page-top--links"
+                >
+                  <span class="vd-page-info">共{{ displayCommentTotalPages }}页</span>
                   <template
-                    v-for="(it, pidx) in commentPagerItems"
+                    v-for="(it, pidx) in displayCommentPagerItems"
                     :key="'vd-cmt-page-top-' + pidx"
                   >
                     <span
@@ -620,7 +623,7 @@
                   <button
                     type="button"
                     class="vd-page-next vd-page-next--link"
-                    :disabled="commentCurrentPage >= commentTotalPages"
+                    :disabled="commentCurrentPage >= displayCommentTotalPages"
                     @click="setCommentPage(commentCurrentPage + 1)"
                   >
                     下一页
@@ -716,13 +719,15 @@
                     :video-author-id="mbVideoAuthorId"
                     :highlight-comment-id="mbHighlightCommentId"
                     :initial-comments-curated="!!(apiDetail && apiDetail.comments_curated)"
+                    :page="commentCurrentPage"
+                    :page-size="commentPageSize"
                     @counts="onMbCommentCounts"
                   />
                 </div>
                 <div class="vd-cmt-page-bottom vd-cmt-page-bottom--mb">
                   <div class="vd-cmt-page-bottom-left">
                     <template
-                      v-for="(it, pidx) in commentPagerItems"
+                      v-for="(it, pidx) in displayCommentPagerItems"
                       :key="'vd-cmt-page-mb-' + pidx"
                     >
                       <span
@@ -743,7 +748,7 @@
                     <button
                       type="button"
                       class="vd-page-next vd-page-next--boxed"
-                      :disabled="commentCurrentPage >= commentTotalPages"
+                      :disabled="commentCurrentPage >= displayCommentTotalPages"
                       @click="setCommentPage(commentCurrentPage + 1)"
                     >
                       下一页
@@ -751,7 +756,7 @@
                   </div>
                   <div class="vd-cmt-page-bottom-right">
                     <span class="vd-page-bottom-meta"
-                      >共{{ commentTotalPages }}页，跳至</span
+                      >共{{ displayCommentTotalPages }}页，跳至</span
                     >
                     <input
                       v-model="commentPageJumpDraft"
@@ -794,7 +799,7 @@
 
             <ul class="vd-cmt-list">
               <li
-                v-for="(thread, ti) in commentThreads"
+                v-for="(thread, ti) in mockCommentThreads"
                 :key="ti"
                 class="vd-cmt-thread"
               >
@@ -1006,10 +1011,13 @@
               </li>
             </ul>
 
-            <div class="vd-cmt-page-bottom vd-cmt-page-bottom--mock">
+            <div
+              v-if="isMb"
+              class="vd-cmt-page-bottom vd-cmt-page-bottom--mock"
+            >
               <div class="vd-cmt-page-bottom-left">
                 <template
-                  v-for="(it, pidx) in commentPagerItems"
+                  v-for="(it, pidx) in displayCommentPagerItems"
                   :key="'vd-cmt-page-bot-' + pidx"
                 >
                   <span
@@ -1030,7 +1038,7 @@
                 <button
                   type="button"
                   class="vd-page-next vd-page-next--boxed"
-                  :disabled="commentCurrentPage >= commentTotalPages"
+                  :disabled="commentCurrentPage >= displayCommentTotalPages"
                   @click="setCommentPage(commentCurrentPage + 1)"
                 >
                   下一页
@@ -1038,7 +1046,7 @@
               </div>
               <div class="vd-cmt-page-bottom-right">
                 <span class="vd-page-bottom-meta"
-                  >共{{ commentTotalPages }}页，跳至</span
+                  >共{{ displayCommentTotalPages }}页，跳至</span
                 >
                 <input
                   v-model="commentPageJumpDraft"
@@ -1268,6 +1276,7 @@ export default {
       commentTotalPages: 138,
       /** 评论区页码（当前列表未接后端分页时仅用于顶栏/底栏展示与跳转） */
       commentCurrentPage: 1,
+      commentPageSize: 20,
       commentPageJumpDraft: "1",
       commentPlaceholder:
         "只是一直在等你而已，才不是想被评论呢~",
@@ -1717,10 +1726,26 @@ export default {
         !this.mbCommentPosting
       );
     },
-    commentPagerItems() {
+    mockCommentTotalPages() {
+      const n = (this.commentThreads || []).length;
+      return Math.max(1, Math.ceil(n / this.commentPageSize));
+    },
+    /** 当前展示形态下的总页数：移动端真实评论用接口计数，桌面演示评论用演示数据条数 */
+    displayCommentTotalPages() {
+      return this.isMb ? this.commentTotalPages : this.mockCommentTotalPages;
+    },
+    /** 桌面演示评论区：按当前页切片（移动端走 CakecakeCommentsLive 内部切片） */
+    mockCommentThreads() {
+      const start = (this.commentCurrentPage - 1) * this.commentPageSize;
+      return (this.commentThreads || []).slice(
+        start,
+        start + this.commentPageSize
+      );
+    },
+    displayCommentPagerItems() {
       const total = Math.max(
         1,
-        parseInt(String(this.commentTotalPages), 10) || 1
+        parseInt(String(this.displayCommentTotalPages), 10) || 1
       );
       const cur = Math.min(
         Math.max(1, parseInt(String(this.commentCurrentPage), 10) || 1),
@@ -2092,11 +2117,14 @@ export default {
         /* 保留空列表或上一批数据 */
       }
     },
-    onMbCommentCounts(n) {
-      const v = Number(n);
+    onMbCommentCounts(total, totalPages) {
+      const v = Number(total);
       if (Number.isNaN(v)) return;
       this.commentTotal = v;
-      this.commentTotalPages = Math.max(1, Math.ceil(v / 20));
+      const pages = Number(totalPages);
+      this.commentTotalPages = Number.isFinite(pages) && pages >= 1
+        ? Math.floor(pages)
+        : Math.max(1, Math.ceil(v / 20));
       if (this.commentCurrentPage > this.commentTotalPages) {
         this.commentCurrentPage = this.commentTotalPages;
       }
@@ -2105,7 +2133,7 @@ export default {
     setCommentPage(n) {
       const t = Math.max(
         1,
-        parseInt(String(this.commentTotalPages), 10) || 1
+        parseInt(String(this.displayCommentTotalPages), 10) || 1
       );
       const raw = parseInt(String(n), 10);
       const p = Number.isFinite(raw)

--- a/internal/client/CommentSvc.go
+++ b/internal/client/CommentSvc.go
@@ -23,9 +23,9 @@ type CommentSvc interface {
 	IgnoreArticleComment(ctx context.Context, commentID uint64) error
 	IgnoreCuratedComment(ctx context.Context, commentID uint64) error
 	IgnoreDynComment(ctx context.Context, commentID uint64) error
-	ListArticleComments(ctx context.Context, articleID uint64, viewerID uint64) (*servicecomment.CommentListResult, error)
-	ListComments(ctx context.Context, videoID uint64, viewerID uint64) (*servicecomment.CommentListResult, error)
-	ListDynamicComments(ctx context.Context, dynamicID uint64, viewerID uint64) (*servicecomment.CommentListResult, error)
+	ListArticleComments(ctx context.Context, articleID uint64, viewerID uint64, q servicecomment.CommentListQuery) (*servicecomment.CommentListResult, error)
+	ListComments(ctx context.Context, videoID uint64, viewerID uint64, q servicecomment.CommentListQuery) (*servicecomment.CommentListResult, error)
+	ListDynamicComments(ctx context.Context, dynamicID uint64, viewerID uint64, q servicecomment.CommentListQuery) (*servicecomment.CommentListResult, error)
 	PinArticleComment(ctx context.Context, articleID uint64, commentID uint64) (bool, error)
 	PinComment(ctx context.Context, videoID uint64, commentID uint64) (bool, error)
 	PostArticleComment(ctx context.Context, userID uint64, articleID uint64, req servicecomment.PostCommentReq, ipLocation string) (*comment.ArticleComment, error)

--- a/internal/handler/article_comment.go
+++ b/internal/handler/article_comment.go
@@ -37,6 +37,10 @@ type articleCommentListResponse struct {
 	Items           []articleCommentItemDTO `json:"items"`
 	CommentsCurated bool                    `json:"comments_curated"`
 	CommentsClosed  bool                    `json:"comments_closed"`
+	Page            int                     `json:"page"`
+	PageSize        int                     `json:"page_size"`
+	Total           int64                   `json:"total"`
+	TotalPages      int                     `json:"total_pages"`
 }
 
 type postArticleCommentResponse struct {
@@ -57,7 +61,7 @@ func (a *API) ListArticleComments(c *gin.Context) {
 		return
 	}
 	uid, _ := middleware.UserID(c)
-	result, svcErr := a.CommentSvc.ListArticleComments(c.Request.Context(), aid, uid)
+	result, svcErr := a.CommentSvc.ListArticleComments(c.Request.Context(), aid, uid, parseCommentListQuery(c))
 	if svcErr != nil {
 		resp.Err(c, httpStatusFromSvc(errCodeFromSvc(svcErr)), errCodeFromSvc(svcErr))
 		return
@@ -74,7 +78,10 @@ func (a *API) ListArticleComments(c *gin.Context) {
 			IPLocation: iplocate.DisplayLabel(item.IPLocation),
 		})
 	}
-	resp.OK(c, articleCommentListResponse{Items: out, CommentsCurated: result.CommentsCurated, CommentsClosed: result.CommentsClosed})
+	resp.OK(c, articleCommentListResponse{
+		Items: out, CommentsCurated: result.CommentsCurated, CommentsClosed: result.CommentsClosed,
+		Page: result.Page, PageSize: result.PageSize, Total: result.Total, TotalPages: result.TotalPages,
+	})
 }
 
 // PostArticleComment creates a comment on an article.

--- a/internal/handler/comment.go
+++ b/internal/handler/comment.go
@@ -48,6 +48,28 @@ type commentListResponse struct {
 	Items           []commentItemDTO `json:"items"`
 	CommentsCurated bool             `json:"comments_curated"`
 	CommentsClosed  bool             `json:"comments_closed"`
+	Page            int              `json:"page"`
+	PageSize        int              `json:"page_size"`
+	Total           int64            `json:"total"`
+	TotalPages      int              `json:"total_pages"`
+}
+
+// parseCommentListQuery reads page/page_size/sort with safe defaults.
+func parseCommentListQuery(c *gin.Context) comment.CommentListQuery {
+	parse := func(raw string, def int) int {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return def
+		}
+		return n
+	}
+	q := comment.CommentListQuery{
+		Page:     parse(c.DefaultQuery("page", "1"), 1),
+		PageSize: parse(c.DefaultQuery("page_size", "20"), 20),
+		Sort:     c.DefaultQuery("sort", "hot"),
+	}
+	page, pageSize, sort := q.Normalized()
+	return comment.CommentListQuery{Page: page, PageSize: pageSize, Sort: sort}
 }
 
 type postCommentResponse struct {
@@ -154,7 +176,7 @@ func (a *API) ListComments(c *gin.Context) {
 		return
 	}
 	uid, _ := middleware.UserID(c)
-	result, svcErr := a.CommentSvc.ListComments(c.Request.Context(), vid, uid)
+	result, svcErr := a.CommentSvc.ListComments(c.Request.Context(), vid, uid, parseCommentListQuery(c))
 	if svcErr != nil {
 		resp.Err(c, httpStatusFromSvc(errCodeFromSvc(svcErr)), errCodeFromSvc(svcErr))
 		return
@@ -171,7 +193,10 @@ func (a *API) ListComments(c *gin.Context) {
 			IPLocation: iplocate.DisplayLabel(item.IPLocation),
 		})
 	}
-	resp.OK(c, commentListResponse{Items: out, CommentsCurated: result.CommentsCurated, CommentsClosed: result.CommentsClosed})
+	resp.OK(c, commentListResponse{
+		Items: out, CommentsCurated: result.CommentsCurated, CommentsClosed: result.CommentsClosed,
+		Page: result.Page, PageSize: result.PageSize, Total: result.Total, TotalPages: result.TotalPages,
+	})
 }
 
 // PostComment creates a comment or reply.

--- a/internal/handler/dynamic_comment.go
+++ b/internal/handler/dynamic_comment.go
@@ -37,6 +37,10 @@ type dynamicCommentListResponse struct {
 	Items           []dynamicCommentItemDTO `json:"items"`
 	CommentsCurated bool                    `json:"comments_curated"`
 	CommentsClosed  bool                    `json:"comments_closed"`
+	Page            int                     `json:"page"`
+	PageSize        int                     `json:"page_size"`
+	Total           int64                   `json:"total"`
+	TotalPages      int                     `json:"total_pages"`
 }
 
 type postDynamicCommentResponse struct {
@@ -55,7 +59,7 @@ func (a *API) ListDynamicComments(c *gin.Context) {
 		return
 	}
 	uid, _ := middleware.UserID(c)
-	result, svcErr := a.CommentSvc.ListDynamicComments(c.Request.Context(), did, uid)
+	result, svcErr := a.CommentSvc.ListDynamicComments(c.Request.Context(), did, uid, parseCommentListQuery(c))
 	if svcErr != nil {
 		resp.Err(c, httpStatusFromSvc(errCodeFromSvc(svcErr)), errCodeFromSvc(svcErr))
 		return
@@ -71,7 +75,10 @@ func (a *API) ListDynamicComments(c *gin.Context) {
 			IPLocation: iplocate.DisplayLabel(item.IPLocation), IsByUploader: item.IsByUploader,
 		})
 	}
-	resp.OK(c, dynamicCommentListResponse{Items: out, CommentsCurated: result.CommentsCurated, CommentsClosed: result.CommentsClosed})
+	resp.OK(c, dynamicCommentListResponse{
+		Items: out, CommentsCurated: result.CommentsCurated, CommentsClosed: result.CommentsClosed,
+		Page: result.Page, PageSize: result.PageSize, Total: result.Total, TotalPages: result.TotalPages,
+	})
 }
 
 // PostDynamicComment creates a comment on a dynamic.

--- a/internal/service/comment/comment.go
+++ b/internal/service/comment/comment.go
@@ -59,17 +59,50 @@ type CommentListResult struct {
 	Items           []CommentItem
 	CommentsCurated bool
 	CommentsClosed  bool
+	Page            int
+	PageSize        int
+	Total           int64
+	TotalPages      int
+}
+
+// CommentListQuery carries the pagination and ordering of a public comment
+// list. Zero values fall back to page 1 / 20 items / hot ordering.
+type CommentListQuery struct {
+	Page     int
+	PageSize int
+	Sort     string
+}
+
+// Normalized returns the query with safe defaults applied.
+func (q CommentListQuery) Normalized() (page, pageSize int, sort string) {
+	page = q.Page
+	if page < 1 {
+		page = 1
+	}
+	pageSize = q.PageSize
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > 50 {
+		pageSize = 50
+	}
+	sort = q.Sort
+	if sort != "time" {
+		sort = "hot"
+	}
+	return page, pageSize, sort
 }
 
 // ListComments lists comments on a video with viewer interaction flags.
-func (s *CommentService) ListComments(ctx context.Context, videoID, viewerID uint64) (*CommentListResult, error) {
+func (s *CommentService) ListComments(ctx context.Context, videoID, viewerID uint64, q CommentListQuery) (*CommentListResult, error) {
 	v, err := s.videos.GetPublishedVideo(ctx, videoID)
 	if err != nil {
 		return nil, service.ErrNotFound
 	}
 	return s.buildCommentList(ctx, videoID, viewerID, v.UserID, v.CommentsCurated, v.CommentsClosed,
-		func(ctx context.Context, targetID uint64, curated bool) ([]commentListRow, error) {
-			return s.comments.ListComments(ctx, CommentVideo, targetID, curated)
+		q,
+		func(ctx context.Context, targetID uint64, curated bool, q CommentListQuery) (*CommentPage, error) {
+			return s.comments.ListCommentsPage(ctx, CommentVideo, targetID, curated, q)
 		},
 		func(ctx context.Context, viewerID uint64, ids []uint64) (map[uint64]bool, map[uint64]bool, error) {
 			liked, err := s.loadCommentLikesByIDs(ctx, viewerID, ids)
@@ -210,14 +243,15 @@ func (s *CommentService) GetDynamicCommentByID(ctx context.Context, commentID ui
 // ─── Article Comments ───
 
 // ListArticleComments lists comments on an article with viewer interaction flags.
-func (s *CommentService) ListArticleComments(ctx context.Context, articleID, viewerID uint64) (*CommentListResult, error) {
+func (s *CommentService) ListArticleComments(ctx context.Context, articleID, viewerID uint64, q CommentListQuery) (*CommentListResult, error) {
 	a, err := s.articles.GetPublishedArticle(ctx, articleID)
 	if err != nil {
 		return nil, service.ErrNotFound
 	}
 	return s.buildCommentList(ctx, articleID, viewerID, a.UserID, a.CommentsCurated, a.CommentsClosed,
-		func(ctx context.Context, targetID uint64, curated bool) ([]commentListRow, error) {
-			return s.comments.ListComments(ctx, CommentArticle, targetID, curated)
+		q,
+		func(ctx context.Context, targetID uint64, curated bool, q CommentListQuery) (*CommentPage, error) {
+			return s.comments.ListCommentsPage(ctx, CommentArticle, targetID, curated, q)
 		},
 		func(ctx context.Context, viewerID uint64, ids []uint64) (map[uint64]bool, map[uint64]bool, error) {
 			return s.loadArticleReactionsByIDs(ctx, viewerID, ids)
@@ -343,14 +377,15 @@ func (s *CommentService) GetArticleComment(ctx context.Context, commentID uint64
 // ─── Dynamic Comments ───
 
 // ListDynamicComments lists comments on a dynamic with viewer interaction flags.
-func (s *CommentService) ListDynamicComments(ctx context.Context, dynamicID, viewerID uint64) (*CommentListResult, error) {
+func (s *CommentService) ListDynamicComments(ctx context.Context, dynamicID, viewerID uint64, q CommentListQuery) (*CommentListResult, error) {
 	d, err := s.dynamics.GetPublishedDynamic(ctx, dynamicID)
 	if err != nil {
 		return nil, service.ErrNotFound
 	}
 	return s.buildCommentList(ctx, dynamicID, viewerID, d.UserID, d.CommentsCurated, d.CommentsClosed,
-		func(ctx context.Context, targetID uint64, curated bool) ([]commentListRow, error) {
-			return s.comments.ListComments(ctx, CommentDynamic, targetID, curated)
+		q,
+		func(ctx context.Context, targetID uint64, curated bool, q CommentListQuery) (*CommentPage, error) {
+			return s.comments.ListCommentsPage(ctx, CommentDynamic, targetID, curated, q)
 		},
 		nil)
 }

--- a/internal/service/comment/comment_provider.go
+++ b/internal/service/comment/comment_provider.go
@@ -18,13 +18,20 @@ const (
 	CommentDynamic
 )
 
+// CommentPage is one page of root comments plus their full reply subtrees.
+type CommentPage struct {
+	Rows  []commentListRow
+	Total int64
+}
+
 // CommentProvider is the comment domain storage boundary.
 // Phase 1: *gorm.DB impl. Phase 2+: replaced by gRPC client / per-domain store.
 type CommentProvider interface {
 	// WithTx runs fn inside a database transaction (Phase 1 monolith seam).
 	WithTx(ctx context.Context, fn func(tx *gorm.DB) error) error
-	// ListComments returns the target's comment rows (approved-filtered when curated).
-	ListComments(ctx context.Context, kind CommentKind, targetID uint64, curated bool) ([]commentListRow, error)
+	// ListCommentsPage returns one page of root comments with their full reply
+	// subtrees (approved-filtered when curated).
+	ListCommentsPage(ctx context.Context, kind CommentKind, targetID uint64, curated bool, q CommentListQuery) (*CommentPage, error)
 
 	// Typed creates.
 	CreateVideoComment(ctx context.Context, cm *comment.Comment) error
@@ -130,34 +137,110 @@ func commentDislikeModel(kind CommentKind) interface{} {
 	}
 }
 
-// ListComments lists comments of the given kind for a target media id,
-// optionally filtering to curated-approved rows.
-func (p *CommentProviderImpl) ListComments(ctx context.Context, kind CommentKind, targetID uint64, curated bool) ([]commentListRow, error) {
+// ListCommentsPage lists one page of root comments of the given kind for a
+// target media id, together with every descendant reply of those roots, so the
+// client can rebuild complete threads without loading the whole table.
+func (p *CommentProviderImpl) ListCommentsPage(ctx context.Context, kind CommentKind, targetID uint64, curated bool, q CommentListQuery) (*CommentPage, error) {
+	page, pageSize, sort := q.Normalized()
 	col := commentTargetColumn(kind)
-	q := p.db.WithContext(ctx).Where(col+" = ?", targetID)
-	if curated {
-		q = q.Where("approved = ?", true)
-	}
 	switch kind {
 	case CommentArticle:
-		var list []comment.ArticleComment
-		if err := q.Order("id ASC").Find(&list).Error; err != nil {
-			return nil, err
-		}
-		return toArticleCommentRows(list), nil
+		return listCommentPage(ctx, p.db, col, targetID, curated, page, pageSize, sort,
+			toArticleCommentRows,
+			func(c *comment.ArticleComment) uint64 { return c.ID })
 	case CommentDynamic:
-		var list []comment.DynamicComment
-		if err := q.Order("id ASC").Find(&list).Error; err != nil {
-			return nil, err
-		}
-		return toDynamicCommentRows(list), nil
+		return listCommentPage(ctx, p.db, col, targetID, curated, page, pageSize, sort,
+			toDynamicCommentRows,
+			func(c *comment.DynamicComment) uint64 { return c.ID })
 	default:
-		var list []comment.Comment
-		if err := q.Order("id ASC").Find(&list).Error; err != nil {
+		return listCommentPage(ctx, p.db, col, targetID, curated, page, pageSize, sort,
+			toCommentRows,
+			func(c *comment.Comment) uint64 { return c.ID })
+	}
+}
+
+// commentRootOrder returns the stable DB ordering for root comments:
+// pinned first, then hot (like count) or time (created_at).
+func commentRootOrder(sort string) string {
+	if sort == "time" {
+		return "pinned DESC, created_at DESC, id DESC"
+	}
+	return "pinned DESC, like_count DESC, id DESC"
+}
+
+// listCommentPage is the shared paged root-comment query for one comment table.
+func listCommentPage[R any](
+	ctx context.Context,
+	db *gorm.DB,
+	targetCol string,
+	targetID uint64,
+	curated bool,
+	page, pageSize int,
+	sort string,
+	mapper func([]R) []commentListRow,
+	idOf func(*R) uint64,
+) (*CommentPage, error) {
+	base := func() *gorm.DB {
+		q := db.WithContext(ctx).Model(new(R)).Where(targetCol+" = ?", targetID)
+		if curated {
+			q = q.Where("approved = ?", true)
+		}
+		return q
+	}
+
+	var total int64
+	if err := base().Where("parent_id = ?", 0).Count(&total).Error; err != nil {
+		return nil, err
+	}
+	if total == 0 {
+		return &CommentPage{Rows: []commentListRow{}, Total: 0}, nil
+	}
+
+	var roots []R
+	if err := base().
+		Where("parent_id = ?", 0).
+		Order(commentRootOrder(sort)).
+		Limit(pageSize).
+		Offset((page - 1) * pageSize).
+		Find(&roots).Error; err != nil {
+		return nil, err
+	}
+	if len(roots) == 0 {
+		return &CommentPage{Rows: []commentListRow{}, Total: total}, nil
+	}
+
+	all := make([]R, 0, len(roots))
+	seen := make(map[uint64]bool, len(roots))
+	parentIDs := make([]uint64, 0, len(roots))
+	for i := range roots {
+		all = append(all, roots[i])
+		id := idOf(&roots[i])
+		seen[id] = true
+		parentIDs = append(parentIDs, id)
+	}
+	// Replies are nested at most a few levels; a small iteration cap keeps the
+	// query bounded even if the data ever contains a deep chain.
+	for depth := 0; depth < 6 && len(parentIDs) > 0; depth++ {
+		var kids []R
+		if err := base().
+			Where("parent_id IN ?", parentIDs).
+			Order("id ASC").
+			Find(&kids).Error; err != nil {
 			return nil, err
 		}
-		return toCommentRows(list), nil
+		next := make([]uint64, 0, len(kids))
+		for i := range kids {
+			id := idOf(&kids[i])
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+			all = append(all, kids[i])
+			next = append(next, id)
+		}
+		parentIDs = next
 	}
+	return &CommentPage{Rows: mapper(all), Total: total}, nil
 }
 
 // CreateVideoComment inserts a video comment row.

--- a/internal/service/comment/comment_provider_paging_test.go
+++ b/internal/service/comment/comment_provider_paging_test.go
@@ -1,0 +1,77 @@
+package comment
+
+import (
+	"context"
+	"testing"
+
+	"cakecake/internal/model/comment"
+
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newPagingCommentDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&comment.Comment{}))
+	return db
+}
+
+func TestListCommentsPage_RootsWithReplies(t *testing.T) {
+	db := newPagingCommentDB(t)
+	ctx := context.Background()
+	for i := 1; i <= 5; i++ {
+		root := comment.Comment{VideoID: 10, UserID: 1, Content: "root", Level: 1, LikeCount: uint64(i), Approved: true}
+		require.NoError(t, db.Create(&root).Error)
+		child := comment.Comment{VideoID: 10, UserID: 2, ParentID: root.ID, Level: 2, Content: "child", Approved: true}
+		require.NoError(t, db.Create(&child).Error)
+		grand := comment.Comment{VideoID: 10, UserID: 3, ParentID: child.ID, Level: 3, Content: "grand", Approved: true}
+		require.NoError(t, db.Create(&grand).Error)
+	}
+
+	p := NewCommentProvider(db)
+	pg, err := p.ListCommentsPage(ctx, CommentVideo, 10, false, CommentListQuery{Page: 2, PageSize: 2, Sort: "hot"})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), pg.Total)
+	// Page 2 of hot order (like_count desc) = roots with like_count 3 and 2,
+	// each with its child + grandchild: 2 * 3 = 6 rows.
+	require.Len(t, pg.Rows, 6)
+
+	var gotRoots []commentListRow
+	for _, r := range pg.Rows {
+		if r.ParentID == 0 {
+			gotRoots = append(gotRoots, r)
+		}
+	}
+	require.Len(t, gotRoots, 2)
+	require.Equal(t, uint64(3), gotRoots[0].LikeCount)
+	require.Equal(t, uint64(2), gotRoots[1].LikeCount)
+}
+
+func TestListCommentsPage_CuratedFiltersApproved(t *testing.T) {
+	db := newPagingCommentDB(t)
+	ctx := context.Background()
+	root := comment.Comment{VideoID: 11, UserID: 1, Content: "approved", Level: 1, Approved: true}
+	require.NoError(t, db.Create(&root).Error)
+	require.NoError(t, db.Create(&comment.Comment{VideoID: 11, UserID: 1, Content: "pending", Level: 1, Approved: false}).Error)
+	require.NoError(t, db.Create(&comment.Comment{VideoID: 11, UserID: 2, ParentID: root.ID, Level: 2, Content: "reply-pending", Approved: false}).Error)
+
+	p := NewCommentProvider(db)
+	pg, err := p.ListCommentsPage(ctx, CommentVideo, 11, true, CommentListQuery{Page: 1, PageSize: 20, Sort: "hot"})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), pg.Total)
+	require.Len(t, pg.Rows, 1)
+	require.Equal(t, "approved", pg.Rows[0].Content)
+}
+
+func TestCommentTotalPages(t *testing.T) {
+	require.Equal(t, 1, commentTotalPages(0, 20))
+	require.Equal(t, 1, commentTotalPages(20, 20))
+	require.Equal(t, 2, commentTotalPages(21, 20))
+	require.Equal(t, 3, commentTotalPages(41, 20))
+}

--- a/internal/service/comment/comment_test.go
+++ b/internal/service/comment/comment_test.go
@@ -86,7 +86,7 @@ func TestCommentService_PostAndList(t *testing.T) {
 	require.NoError(t, db.Model(&video.Video{}).Where("id = ?", 10).Update("comments_closed", true).Error)
 	_, err = s.PostComment(ctx, 2, 10, PostCommentReq{Content: "x"}, "")
 	require.ErrorIs(t, err, service.ErrCommentsClosed)
-	res, err := s.ListComments(ctx, 10, 2)
+	res, err := s.ListComments(ctx, 10, 2, CommentListQuery{})
 	require.NoError(t, err)
 	require.True(t, res.CommentsClosed)
 	require.Empty(t, res.Items)
@@ -94,7 +94,7 @@ func TestCommentService_PostAndList(t *testing.T) {
 
 	// List with reactions.
 	require.NoError(t, db.Create(&comment.CommentLike{UserID: 2, CommentID: cm.ID}).Error)
-	res, err = s.ListComments(ctx, 10, 2)
+	res, err = s.ListComments(ctx, 10, 2, CommentListQuery{})
 	require.NoError(t, err)
 	require.Len(t, res.Items, 2)
 	require.False(t, res.CommentsClosed)
@@ -104,7 +104,7 @@ func TestCommentService_PostAndList(t *testing.T) {
 	curated, err := s.PostComment(ctx, 2, 10, PostCommentReq{Content: "pending"}, "")
 	require.NoError(t, err)
 	require.False(t, curated.Approved)
-	res, err = s.ListComments(ctx, 10, 2)
+	res, err = s.ListComments(ctx, 10, 2, CommentListQuery{})
 	require.NoError(t, err)
 	require.True(t, res.CommentsCurated)
 	require.Len(t, res.Items, 2) // only approved
@@ -221,14 +221,14 @@ func TestCommentService_ArticleAndDynamic(t *testing.T) {
 	ac, err := s.PostArticleComment(ctx, 2, 20, PostCommentReq{Content: "article cmt"}, "")
 	require.NoError(t, err)
 	require.NotZero(t, ac.ID)
-	ares, err := s.ListArticleComments(ctx, 20, 2)
+	ares, err := s.ListArticleComments(ctx, 20, 2, CommentListQuery{})
 	require.NoError(t, err)
 	require.Len(t, ares.Items, 1)
 
 	// Missing article.
 	_, err = s.PostArticleComment(ctx, 2, 999, PostCommentReq{Content: "x"}, "")
 	require.ErrorIs(t, err, service.ErrNotFound)
-	_, err = s.ListArticleComments(ctx, 999, 2)
+	_, err = s.ListArticleComments(ctx, 999, 2, CommentListQuery{})
 	require.ErrorIs(t, err, service.ErrNotFound)
 
 	pinned, err := s.PinArticleComment(ctx, 20, ac.ID)
@@ -250,12 +250,12 @@ func TestCommentService_ArticleAndDynamic(t *testing.T) {
 
 	dc, err := s.PostDynamicComment(ctx, 2, 30, PostCommentReq{Content: "dyn cmt"}, "")
 	require.NoError(t, err)
-	dres, err := s.ListDynamicComments(ctx, 30, 2)
+	dres, err := s.ListDynamicComments(ctx, 30, 2, CommentListQuery{})
 	require.NoError(t, err)
 	require.Len(t, dres.Items, 1)
 	_, err = s.PostDynamicComment(ctx, 2, 999, PostCommentReq{Content: "x"}, "")
 	require.ErrorIs(t, err, service.ErrNotFound)
-	_, err = s.ListDynamicComments(ctx, 999, 2)
+	_, err = s.ListDynamicComments(ctx, 999, 2, CommentListQuery{})
 	require.ErrorIs(t, err, service.ErrNotFound)
 
 	liked, count, err := s.ToggleDynamicCommentReaction(ctx, 2, dc.ID, true)

--- a/internal/service/comment/comment_unified.go
+++ b/internal/service/comment/comment_unified.go
@@ -71,18 +71,28 @@ func (s *CommentService) buildCommentList(
 	ctx context.Context,
 	targetID, viewerID, ownerID uint64,
 	curated, closed bool,
-	load func(ctx context.Context, targetID uint64, curated bool) ([]commentListRow, error),
+	q CommentListQuery,
+	load func(ctx context.Context, targetID uint64, curated bool, q CommentListQuery) (*CommentPage, error),
 	react commentReactionLoader,
 ) (*CommentListResult, error) {
-	r := &CommentListResult{CommentsCurated: curated, CommentsClosed: closed}
+	page, pageSize, sort := q.Normalized()
+	r := &CommentListResult{
+		CommentsCurated: curated,
+		CommentsClosed:  closed,
+		Page:            page,
+		PageSize:        pageSize,
+	}
 	if closed {
 		r.Items = []CommentItem{}
 		return r, nil
 	}
-	list, err := load(ctx, targetID, curated)
+	pg, err := load(ctx, targetID, curated, CommentListQuery{Page: page, PageSize: pageSize, Sort: sort})
 	if err != nil {
 		return nil, service.ErrInternalError
 	}
+	r.Total = pg.Total
+	r.TotalPages = commentTotalPages(pg.Total, pageSize)
+	list := pg.Rows
 	if len(list) == 0 {
 		r.Items = []CommentItem{}
 		return r, nil
@@ -126,6 +136,17 @@ func (s *CommentService) buildCommentList(
 	}
 	r.Items = out
 	return r, nil
+}
+
+// commentTotalPages returns the page count for a total, at least 1.
+func commentTotalPages(total int64, pageSize int) int {
+	if total <= 0 {
+		return 1
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	return int((total + int64(pageSize) - 1) / int64(pageSize))
 }
 
 func (s *CommentService) loadCommentLikesByIDs(ctx context.Context, viewerID uint64, ids []uint64) (map[uint64]bool, error) {


### PR DESCRIPTION
Comment pagination was fake everywhere: the backend returned the full comment list and the frontend pagers only changed a page number. This PR makes video/article/dynamic comment lists truly paginated on the server.

## Backend
- `/videos/:id/comments`, `/articles/:id/comments`, `/user-dynamics/:id/comments` now accept `page` / `page_size` / `sort` and return `page`, `page_size`, `total`, `total_pages`.
- Pagination is root-comment based: one page of roots (pinned first, then like_count for hot / created_at for time), each with its full reply subtree, so the existing frontend thread builder keeps working.
- Curated mode still filters to approved rows; page_size is capped at 50.
- `CommentListQuery` normalization and client contract updated; added sqlite provider tests for paging, subtree inclusion and curated filtering.

## Frontend
- `CakecakeCommentsLive` requests `page/page_size/sort` from the server, reloads on page/sort changes, and emits `(total, totalPages)`.
- video page, article/dynamic comment panel (`VdCommentPanelMb`) and personal-space dynamic panel (`MbDynVideoCommentPanel`) all drive the server page through their existing pager UIs; page clamping uses the server total_pages.
- The video page desktop demo comment list no longer shows a fake pager.

## Tests
- Backend: `go build ./...`, `go vet`, provider paging unit tests green.
- Frontend: lint, vue-tsc, 833 tests green (including API tests asserting pagination params).