### PR TITLE
fix(ci): apk upgrade in runtime images to clear container CVE alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/cakecak
 
 FROM alpine:3.22
 
-RUN apk add --no-cache ca-certificates tzdata ffmpeg
+# Upgrade all OS packages to patched versions before installing (container
+# CVE hygiene: the base tag's snapshot may still ship vulnerable packages).
+RUN apk upgrade --no-cache && apk add --no-cache ca-certificates tzdata ffmpeg
 
 WORKDIR /app
 

--- a/cakecake-vue/cakecake-web/Dockerfile
+++ b/cakecake-vue/cakecake-web/Dockerfile
@@ -15,6 +15,9 @@ RUN printf 'VITE_MINIBILI_API=true\nVITE_USE_REMOTE_API=false\nVITE_VIDEO_UPLOAD
 
 FROM nginx:1.27-alpine
 
+# Upgrade all OS packages (openssl/libexpat/c-ares) to patched versions.
+RUN apk upgrade --no-cache
+
 COPY deploy/nginx-compose.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 


### PR DESCRIPTION
## Background

GitHub Code scanning currently reports 88 container-image alerts:

- 12 **error**-level alerts are in the `cakecake-web` runtime image
  (`nginx:1.27-alpine`): openssl / libexpat / c-ares
- The remaining warning/note alerts are OS-layer packages in both the
  backend (alpine) and web images: zlib / xz / libxml2 / musl, etc.

Root cause: the OS packages shipped in the base-image snapshots are outdated;
bumping the image tags alone is not enough.

## Changes

Added `RUN apk upgrade --no-cache` to the runtime stage of both Dockerfiles,
upgrading all OS packages to the patched versions available in the Alpine
repositories:

- `Dockerfile` (backend, alpine:3.22)
- `cakecake-vue/cakecake-web/Dockerfile` (web, nginx:1.27-alpine)

## Verification

- pre-commit (BOM / vet / gofmt / sensitive-scan / EN-sync) passes
- Docker build is verified by the CI `docker-publish` workflow (Docker Hub is
  not reachable from this environment)
- After merging to main, images are rebuilt and pushed automatically, and
  GitHub rescans; the alert count should drop significantly

## Notes

- No meaningful impact on image size or startup (one extra package-upgrade step)
- If low-severity (note/warning) alerts that are not exploitable at runtime
  remain after the rescan, they can be dismissed separately