### PR TITLE
feat(auth): server-side logout invalidates refresh token

### DIFF
--- a/cakecake-vue/cakecake-web/src/api/cakecake.ts
+++ b/cakecake-vue/cakecake-web/src/api/cakecake.ts
@@ -553,6 +553,11 @@ export async function mbRefresh(): Promise<TokenPair> {
 }
 
 export function mbLogout(): void {
+  // 通知服务端把 refresh token 标记失效（尽力而为，失败也照常清本地）。
+  const refreshToken = getRefreshToken();
+  if (refreshToken) {
+    void http.post("/api/v1/auth/logout", { refresh_token: refreshToken }).catch(() => {});
+  }
   clearTokens();
 }
 

--- a/internal/client/AuthSvc.go
+++ b/internal/client/AuthSvc.go
@@ -17,6 +17,7 @@ type AuthSvc interface {
 	FindAdminByUsername(ctx context.Context, username string) (*admin.Admin, error)
 	GetAdminByID(ctx context.Context, id uint64) (*admin.Admin, error)
 	LookupUser(ctx context.Context, reqUsername string) (*user.UserBrief, error)
+	Logout(ctx context.Context, refreshToken string) error
 	MarkAdminRefreshTokenInvalid(ctx context.Context, tokenID string) error
 	Refresh(ctx context.Context, refreshToken string) (*user.RefreshResult, error)
 	Register(ctx context.Context, reqUsername string, reqPassword string) (*user.RegisterResult, error)

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -25,6 +25,10 @@ type refreshReq struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
+type logoutReq struct {
+	RefreshToken string `json:"refresh_token"`
+}
+
 type tokenPairResp struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
@@ -112,4 +116,19 @@ func (a *API) Refresh(c *gin.Context) {
 		return
 	}
 	resp.OK(c, tokenPairResp{AccessToken: result.AccessToken, RefreshToken: result.RefreshToken})
+}
+
+// Logout invalidates the user's refresh token server-side.
+func (a *API) Logout(c *gin.Context) {
+	var req logoutReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		resp.Err(c, http.StatusBadRequest, errcode.CodeParamError)
+		return
+	}
+	if err := a.AuthSvc.Logout(c.Request.Context(), req.RefreshToken); err != nil {
+		a.Log.Error("logout", zap.Error(err))
+		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
+		return
+	}
+	resp.OK(c, nil)
 }

--- a/internal/handler/router.go
+++ b/internal/handler/router.go
@@ -97,6 +97,7 @@ func registerUserRoutes(r *gin.Engine, pub, admin, authd *gin.RouterGroup, a *AP
 	pub.POST("/users", a.Register)
 	pub.POST("/auth/login", a.Login)
 	pub.POST("/auth/refresh", a.Refresh)
+	pub.POST("/auth/logout", a.Logout)
 	pub.GET("/space/:userId", middleware.OptionalJWT(jwtm), a.GetUserPublic)
 	pub.GET("/space/:userId/recent-coins", middleware.OptionalJWT(jwtm), a.ListUserRecentCoinVideos)
 	pub.GET("/space/:userId/following", middleware.OptionalJWT(jwtm), a.ListUserFollowing)

--- a/internal/service/user/auth.go
+++ b/internal/service/user/auth.go
@@ -201,6 +201,18 @@ func (s *AuthService) Refresh(ctx context.Context, refreshToken string) (*Refres
 	return &RefreshResult{AccessToken: access, RefreshToken: refresh}, nil
 }
 
+// Logout invalidates a refresh token server-side so it can no longer mint a
+// new pair. Idempotent: an already-invalid or unparsable token still returns
+// success, because the client clears local state regardless.
+func (s *AuthService) Logout(ctx context.Context, refreshToken string) error {
+	_, tokenID, err := s.jwt.ParseRefresh(strings.TrimSpace(refreshToken))
+	if err != nil {
+		return nil
+	}
+	_ = s.rdb.Set(ctx, data.RefreshInvalidKey(tokenID), "1", data.RefreshInvalidTTL).Err()
+	return nil
+}
+
 // FindAdminByUsername looks up an admin by username.
 func (s *AuthService) FindAdminByUsername(ctx context.Context, username string) (*admin.Admin, error) {
 	return s.admins.FindAdminByUsername(ctx, username)

--- a/internal/service/user/auth_test.go
+++ b/internal/service/user/auth_test.go
@@ -88,6 +88,25 @@ func TestAuthService_Refresh(t *testing.T) {
 	require.ErrorIs(t, err, service.ErrUnauthorized)
 }
 
+func TestAuthService_Logout(t *testing.T) {
+	s, _ := newAuthService(t)
+	ctx := context.Background()
+	res, err := s.Register(ctx, "alice", "password123")
+	require.NoError(t, err)
+	authRes, err := s.Authenticate(ctx, res.UserID, "password123")
+	require.NoError(t, err)
+
+	// Logout invalidates the refresh token server-side.
+	require.NoError(t, s.Logout(ctx, authRes.RefreshToken))
+	_, err = s.Refresh(ctx, authRes.RefreshToken)
+	require.ErrorIs(t, err, service.ErrUnauthorized)
+
+	// Idempotent: logging out again is still a success.
+	require.NoError(t, s.Logout(ctx, authRes.RefreshToken))
+	// Garbage token: no error, client-side cleanup still proceeds.
+	require.NoError(t, s.Logout(ctx, "not-a-jwt"))
+}
+
 func TestAuthService_AdminTokens(t *testing.T) {
 	s, db := newAuthService(t)
 	ctx := context.Background()


### PR DESCRIPTION
- AuthService.Logout marks the refresh tokenID invalid in Redis (blacklist), idempotent for already-invalid or unparsable tokens
- POST /api/v1/auth/logout handler + route
- frontend mbLogout calls the endpoint (best-effort) before clearing local tokens
- service test: logout -> refresh rejected; idempotent; garbage token ok