### PR TITLE
feat(auth): password change invalidates all refresh tokens via epoch

### DIFF
--- a/internal/client/AuthSvc.go
+++ b/internal/client/AuthSvc.go
@@ -14,6 +14,7 @@ import (
 type AuthSvc interface {
 	AdminRefreshTokenInvalid(ctx context.Context, tokenID string) bool
 	Authenticate(ctx context.Context, userID uint64, password string) (*user.AuthenticateResult, error)
+	BumpRefreshEpoch(ctx context.Context, userID uint64) error
 	FindAdminByUsername(ctx context.Context, username string) (*admin.Admin, error)
 	GetAdminByID(ctx context.Context, id uint64) (*admin.Admin, error)
 	LookupUser(ctx context.Context, reqUsername string) (*user.UserBrief, error)

--- a/internal/data/redis.go
+++ b/internal/data/redis.go
@@ -34,6 +34,7 @@ const (
 	PrefixDanmakuCooldown     = "danmaku:cooldown:"
 	PrefixRefreshInvalid      = "refresh_token:invalid:"
 	PrefixAdminRefreshInvalid = "refresh_token:admin:invalid:"
+	PrefixRefreshEpoch        = "refresh_token:epoch:"
 	// PrefixVideoPlayDelta stores incremental views since last flush to MySQL.
 	PrefixVideoPlayDelta = "videodelta:"
 	SetPlayDirty         = "playcount:dirty"
@@ -62,6 +63,13 @@ func DanmakuCooldownKey(userID, videoID uint64) string {
 // RefreshInvalidKey returns the Redis key marking a user's refresh token invalid.
 func RefreshInvalidKey(tokenID string) string {
 	return PrefixRefreshInvalid + tokenID
+}
+
+// RefreshUserEpochKey returns the Redis key storing a user's refresh epoch.
+// Password changes INCR this key; refresh tokens minted before the bump are
+// rejected because their embedded epoch is now stale.
+func RefreshUserEpochKey(userID uint64) string {
+	return fmt.Sprintf("%s%d", PrefixRefreshEpoch, userID)
 }
 
 // AdminRefreshInvalidKey returns the Redis key marking an admin's refresh token invalid.

--- a/internal/handler/user_me.go
+++ b/internal/handler/user_me.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 
 	"cakecake/internal/errcode"
@@ -208,6 +209,10 @@ func (a *API) UpdateMePassword(c *gin.Context) {
 	if err := a.UserSvc.UpdatePassword(c.Request.Context(), uid, string(hash)); err != nil {
 		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
 		return
+	}
+	// 改密后使该用户所有旧 Refresh Token 失效。
+	if err := a.AuthSvc.BumpRefreshEpoch(c.Request.Context(), uid); err != nil {
+		a.Log.Error("bump refresh epoch after password change", zap.Uint64("user_id", uid), zap.Error(err))
 	}
 	resp.OK(c, okResponse{OK: true})
 }

--- a/internal/pkg/jwttoken/jwt.go
+++ b/internal/pkg/jwttoken/jwt.go
@@ -18,10 +18,11 @@ const (
 
 // Claims is the JWT payload (Skill S-009).
 type Claims struct {
-	Principal string `json:"principal,omitempty"` // user | admin; empty legacy tokens = user
-	UserID    uint64 `json:"user_id"`
-	TokenID   string `json:"token_id"`
-	Type      string `json:"type"`
+	Principal    string `json:"principal,omitempty"` // user | admin; empty legacy tokens = user
+	UserID       uint64 `json:"user_id"`
+	TokenID      string `json:"token_id"`
+	Type         string `json:"type"`
+	RefreshEpoch uint64 `json:"refresh_epoch,omitempty"` // bumped on password change; older refreshes rejected
 	jwt.RegisteredClaims
 }
 
@@ -40,6 +41,12 @@ func NewManager(secret string) (*Manager, error) {
 
 // IssuePair returns access token, refresh token, and token id (Skill S-009).
 func (m *Manager) IssuePair(userID uint64) (access string, refresh string, tokenID string, err error) {
+	return m.IssuePairEpoch(userID, 0)
+}
+
+// IssuePairEpoch issues a pair whose refresh token carries the current refresh
+// epoch. Password changes bump the epoch, invalidating all older refreshes.
+func (m *Manager) IssuePairEpoch(userID, epoch uint64) (access string, refresh string, tokenID string, err error) {
 	tokenID = uuid.NewString()
 	now := time.Now()
 	accessClaims := Claims{
@@ -53,10 +60,11 @@ func (m *Manager) IssuePair(userID uint64) (access string, refresh string, token
 		},
 	}
 	refreshClaims := Claims{
-		Principal: PrincipalUser,
-		UserID:    userID,
-		TokenID:   tokenID,
-		Type:      claimTypeRefresh,
+		Principal:    PrincipalUser,
+		UserID:       userID,
+		TokenID:      tokenID,
+		Type:         claimTypeRefresh,
+		RefreshEpoch: epoch,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(now.Add(30 * 24 * time.Hour)),
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -92,17 +100,23 @@ func (m *Manager) ParseAccess(token string) (userID uint64, tokenID string, err 
 
 // ParseRefresh validates a refresh token.
 func (m *Manager) ParseRefresh(token string) (userID uint64, tokenID string, err error) {
+	uid, tid, _, e := m.ParseRefreshEpoch(token)
+	return uid, tid, e
+}
+
+// ParseRefreshEpoch validates a refresh token and returns its refresh epoch.
+func (m *Manager) ParseRefreshEpoch(token string) (userID uint64, tokenID string, epoch uint64, err error) {
 	claims, err := m.parse(token)
 	if err != nil {
-		return 0, "", err
+		return 0, "", 0, err
 	}
 	if claims.Type != claimTypeRefresh {
-		return 0, "", fmt.Errorf("not refresh token")
+		return 0, "", 0, fmt.Errorf("not refresh token")
 	}
 	if claims.Principal != "" && claims.Principal != PrincipalUser {
-		return 0, "", fmt.Errorf("not user token")
+		return 0, "", 0, fmt.Errorf("not user token")
 	}
-	return claims.UserID, claims.TokenID, nil
+	return claims.UserID, claims.TokenID, claims.RefreshEpoch, nil
 }
 
 func (m *Manager) parse(token string) (*Claims, error) {

--- a/internal/service/user/auth.go
+++ b/internal/service/user/auth.go
@@ -160,7 +160,7 @@ func (s *AuthService) Authenticate(ctx context.Context, userID uint64, password 
 	if bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(password)) != nil {
 		return nil, &service.SvcError{Code: 40100, Msg: "invalid credentials"}
 	}
-	access, refresh, _, err := s.jwt.IssuePair(u.ID)
+	access, refresh, _, err := s.jwt.IssuePairEpoch(u.ID, uint64(s.refreshEpoch(ctx, u.ID)))
 	if err != nil {
 		return nil, service.ErrInternalError
 	}
@@ -182,7 +182,7 @@ type RefreshResult struct {
 
 // Refresh rotates a refresh token, invalidating the old one.
 func (s *AuthService) Refresh(ctx context.Context, refreshToken string) (*RefreshResult, error) {
-	uid, tokenID, err := s.jwt.ParseRefresh(strings.TrimSpace(refreshToken))
+	uid, tokenID, tokenEpoch, err := s.jwt.ParseRefreshEpoch(strings.TrimSpace(refreshToken))
 	if err != nil {
 		return nil, service.ErrUnauthorized
 	}
@@ -193,12 +193,36 @@ func (s *AuthService) Refresh(ctx context.Context, refreshToken string) (*Refres
 	if s.rdb.Exists(ctx, data.RefreshInvalidKey(tokenID)).Val() == 1 {
 		return nil, service.ErrUnauthorized
 	}
+	epoch := s.refreshEpoch(ctx, uid)
+	if uint64(epoch) > tokenEpoch {
+		// Password was changed after this token was issued: reject stale refreshes.
+		return nil, service.ErrUnauthorized
+	}
 	_ = s.rdb.Set(ctx, data.RefreshInvalidKey(tokenID), "1", data.RefreshInvalidTTL).Err()
-	access, refresh, _, err := s.jwt.IssuePair(uid)
+	access, refresh, _, err := s.jwt.IssuePairEpoch(uid, uint64(epoch))
 	if err != nil {
 		return nil, service.ErrInternalError
 	}
 	return &RefreshResult{AccessToken: access, RefreshToken: refresh}, nil
+}
+
+// refreshEpoch returns the current refresh epoch for a user (0 when absent).
+func (s *AuthService) refreshEpoch(ctx context.Context, userID uint64) int64 {
+	v, err := s.rdb.Get(ctx, data.RefreshUserEpochKey(userID)).Int64()
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// BumpRefreshEpoch invalidates every previously issued refresh token for a
+// user by advancing the epoch (e.g. after a password change).
+func (s *AuthService) BumpRefreshEpoch(ctx context.Context, userID uint64) error {
+	key := data.RefreshUserEpochKey(userID)
+	if err := s.rdb.Incr(ctx, key).Err(); err != nil {
+		return err
+	}
+	return s.rdb.Expire(ctx, key, data.RefreshInvalidTTL).Err()
 }
 
 // Logout invalidates a refresh token server-side so it can no longer mint a

--- a/internal/service/user/auth_test.go
+++ b/internal/service/user/auth_test.go
@@ -107,6 +107,31 @@ func TestAuthService_Logout(t *testing.T) {
 	require.NoError(t, s.Logout(ctx, "not-a-jwt"))
 }
 
+func TestAuthService_PasswordChangeInvalidatesRefresh(t *testing.T) {
+	s, _ := newAuthService(t)
+	ctx := context.Background()
+	res, err := s.Register(ctx, "alice", "password123")
+	require.NoError(t, err)
+	authRes, err := s.Authenticate(ctx, res.UserID, "password123")
+	require.NoError(t, err)
+
+	// Rotate once: ref1 is a fresh token at epoch 0, not yet blacklisted.
+	ref1, err := s.Refresh(ctx, authRes.RefreshToken)
+	require.NoError(t, err)
+
+	// Password change bumps the epoch: ref1 (epoch 0) must now be rejected.
+	require.NoError(t, s.BumpRefreshEpoch(ctx, res.UserID))
+	_, err = s.Refresh(ctx, ref1.RefreshToken)
+	require.ErrorIs(t, err, service.ErrUnauthorized)
+
+	// A token minted after the bump refreshes normally.
+	auth2, err := s.Authenticate(ctx, res.UserID, "password123")
+	require.NoError(t, err)
+	ref2, err := s.Refresh(ctx, auth2.RefreshToken)
+	require.NoError(t, err)
+	require.NotEmpty(t, ref2.RefreshToken)
+}
+
 func TestAuthService_AdminTokens(t *testing.T) {
 	s, db := newAuthService(t)
 	ctx := context.Background()


### PR DESCRIPTION
- JWT refresh claims carry a refresh epoch (IssuePairEpoch/ParseRefreshEpoch)
- AuthService.BumpRefreshEpoch INCRs a per-user Redis epoch; Refresh rejects tokens whose embedded epoch is older than the current value
- UpdateMePassword bumps the epoch after a successful password change
- test: token rotated before the bump is rejected; token minted after works