### PR TITLE
feat(search): sync user profile/username changes and user deletion to ES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/INTERVIEW_SPRINT.md
 docs/resume-optimized-go-intern.md
 docs/go语言实习简历模版.pdf
 docs/王子扬.pdf
+docs/王子扬-*.pdf
 docs/loadtest-results/
 jd_analysis/
 bilibili_jd/

--- a/internal/handler/account_deletion.go
+++ b/internal/handler/account_deletion.go
@@ -110,6 +110,8 @@ func maybeFinalizeAccountDeletion(ctx context.Context, a *API, uid uint64) error
 		a.StorageSvc.PurgeVideo(v)
 		a.esDeleteVideo(v.ID)
 	}
+	// 用户已匿名化：IndexUserFromDB 对匿名用户会删除 ES 文档，复用同一入口。
+	a.esIndexUser(uid)
 	return nil
 }
 

--- a/internal/handler/user_me.go
+++ b/internal/handler/user_me.go
@@ -135,6 +135,7 @@ func (a *API) UpdateMeProfile(c *gin.Context) {
 		resp.Err(c, http.StatusInternalServerError, errcode.CodeInternalError)
 		return
 	}
+	a.esIndexUser(uid) // nickname/sign 都在 ES 用户文档里，改后异步重建索引
 	profile, err := a.UserSvc.GetMe(c.Request.Context(), uid)
 	if err != nil {
 		resp.Err(c, http.StatusNotFound, errcode.CodeNotFound)
@@ -168,6 +169,7 @@ func (a *API) UpdateMeUsername(c *gin.Context) {
 		resp.Err(c, http.StatusConflict, errcode.CodeUsernameExists)
 		return
 	}
+	a.esIndexUser(uid) // username 在 ES 用户文档里，改名后异步重建索引
 	resp.OK(c, okResponse{OK: true})
 }
 


### PR DESCRIPTION
- UpdateMeProfile/UpdateMeUsername now async re-index the user (nickname, sign and username are search-match and display fields)
- avatar changes do NOT re-index: search display reads avatar from MySQL at query time (EnrichUserHits overrides unconditionally)
- account deletion finalization re-indexes the user, which deletes the ES doc for anonymized users (IndexUserFromDB removes anonymized docs)