### PR TITLE
feat(search): outbox-style retry for ES sync

### DIFF
--- a/cmd/cakecake/main.go
+++ b/cmd/cakecake/main.go
@@ -226,6 +226,13 @@ func main() {
 		defer wg.Done()
 		worker.StartTranscodeOutboxRelay(ctx, db, mq, log)
 	}()
+	if esc != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			worker.StartSearchSyncRetry(ctx, db, &search.ESClientExecutor{Client: esc, DB: db}, log)
+		}()
+	}
 
 	pc := &playcount.PlayCounter{Rdb: rdb, Store: playcount.NewPlayCountStore(db)}
 	wg.Add(1)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,6 +223,7 @@ sequenceDiagram
 - **高亮**：返回 `<em class="keyword">命中词</em>` 片段
 - **排序**：默认（相关性）、发布日期、播放量、点赞数
 - **可选降级**：ES 未配置时搜索页提示"搜索服务未就绪"，不影响其他功能
+- **数据同步**：业务写 MySQL 后写入 outbox 式待同步表（`search_sync_outbox`），后台 worker 每 5 秒执行并按指数退避重试（10s 起、5min 封顶），成功后标记 done；启动时 `ReindexAll` 全量重建兜底，最终一致
 
 ---
 

--- a/docs/ARCHITECTURE_EN.md
+++ b/docs/ARCHITECTURE_EN.md
@@ -223,6 +223,7 @@ Every publish (upload enqueue, retry scheduling, dead-lettering, admin requeue) 
 - **Highlight**: returns `<em class="keyword">hit</em>` fragments for title and excerpt
 - **Sort support**: default (relevance), pubdate, play_count, like count
 - **Optional**: degrades gracefully when ES is not configured — search page shows "not available" prompt
+- **Data sync**: after a MySQL write, a job is recorded in an outbox-style table (`search_sync_outbox`); a background worker runs every 5s with exponential backoff (10s base, 5min cap) and marks it done on success; startup `ReindexAll` remains the final fallback (eventual consistency)
 
 ---
 

--- a/internal/data/migrate.go
+++ b/internal/data/migrate.go
@@ -10,6 +10,7 @@ import (
 	"cakecake/internal/model/dynamic"
 	"cakecake/internal/model/extra"
 	"cakecake/internal/model/notification"
+	"cakecake/internal/model/search"
 	"cakecake/internal/model/system"
 	"cakecake/internal/model/user"
 	"cakecake/internal/model/video"
@@ -59,7 +60,18 @@ func RegisteredMigrations() []Migration {
 		{29, "transcode_outbox_pinned_names", "recreate outbox/dedup tables with pinned single names", migrateTranscodeOutboxPinnedNames},
 		{30, "transcode_dead_letter_auto_retry", "add auto retry fields to transcode_dead_letters", migrateTranscodeDeadLetterAutoRetry},
 		{31, "draft_object_keys", "rename draft staging paths to OSS object keys", migrateDraftObjectKeys},
+		{32, "search_sync_outbox", "create search_sync_outbox sync table", migrateSearchSyncOutbox},
 	}
+}
+
+func migrateSearchSyncOutbox(db *gorm.DB, lg *zap.Logger) error {
+	if err := db.AutoMigrate(&search.SearchSyncJob{}); err != nil {
+		return err
+	}
+	if lg != nil {
+		lg.Info("created search_sync_outbox table")
+	}
+	return nil
 }
 
 // migrateDraftObjectKeys renames the draft staging columns so the field name

--- a/internal/handler/es_sync.go
+++ b/internal/handler/es_sync.go
@@ -2,72 +2,53 @@ package handler
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
+
+	"cakecake/internal/search"
 )
 
 func (a *API) esIndexVideo(videoID uint64) {
 	if a.SearchSvc == nil || !a.SearchSvc.Enabled() {
 		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if err := a.SearchSvc.IndexVideoFromDB(ctx, videoID); err != nil {
-			a.Log.Warn("elasticsearch index video", zap.Uint64("video_id", videoID), zap.Error(err))
-		}
-	}()
+	if err := search.EnqueueSyncJob(context.Background(), a.DB, search.SyncJobEntityVideo, videoID, search.SyncJobActionUpsert); err != nil && a.Log != nil {
+		a.Log.Warn("enqueue es index video", zap.Uint64("video_id", videoID), zap.Error(err))
+	}
 }
 
 func (a *API) esDeleteVideo(videoID uint64) {
 	if a.SearchSvc == nil || !a.SearchSvc.Enabled() {
 		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := a.SearchSvc.DeleteVideo(ctx, videoID); err != nil {
-			a.Log.Warn("elasticsearch delete video", zap.Uint64("video_id", videoID), zap.Error(err))
-		}
-	}()
+	if err := search.EnqueueSyncJob(context.Background(), a.DB, search.SyncJobEntityVideo, videoID, search.SyncJobActionDelete); err != nil && a.Log != nil {
+		a.Log.Warn("enqueue es delete video", zap.Uint64("video_id", videoID), zap.Error(err))
+	}
 }
 
 func (a *API) esIndexArticle(articleID uint64) {
 	if a.SearchSvc == nil || !a.SearchSvc.Enabled() {
 		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if err := a.SearchSvc.IndexArticleFromDB(ctx, articleID); err != nil {
-			a.Log.Warn("elasticsearch index article", zap.Uint64("article_id", articleID), zap.Error(err))
-		}
-	}()
+	if err := search.EnqueueSyncJob(context.Background(), a.DB, search.SyncJobEntityArticle, articleID, search.SyncJobActionUpsert); err != nil && a.Log != nil {
+		a.Log.Warn("enqueue es index article", zap.Uint64("article_id", articleID), zap.Error(err))
+	}
 }
 
 func (a *API) esDeleteArticle(articleID uint64) {
 	if a.SearchSvc == nil || !a.SearchSvc.Enabled() {
 		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := a.SearchSvc.DeleteArticle(ctx, articleID); err != nil {
-			a.Log.Warn("elasticsearch delete article", zap.Uint64("article_id", articleID), zap.Error(err))
-		}
-	}()
+	if err := search.EnqueueSyncJob(context.Background(), a.DB, search.SyncJobEntityArticle, articleID, search.SyncJobActionDelete); err != nil && a.Log != nil {
+		a.Log.Warn("enqueue es delete article", zap.Uint64("article_id", articleID), zap.Error(err))
+	}
 }
 
 func (a *API) esIndexUser(userID uint64) {
 	if a.SearchSvc == nil || !a.SearchSvc.Enabled() {
 		return
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if err := a.SearchSvc.IndexUserFromDB(ctx, userID); err != nil {
-			a.Log.Warn("elasticsearch index user", zap.Uint64("user_id", userID), zap.Error(err))
-		}
-	}()
+	if err := search.EnqueueSyncJob(context.Background(), a.DB, search.SyncJobEntityUser, userID, search.SyncJobActionUpsert); err != nil && a.Log != nil {
+		a.Log.Warn("enqueue es index user", zap.Uint64("user_id", userID), zap.Error(err))
+	}
 }

--- a/internal/model/search/search_sync.go
+++ b/internal/model/search/search_sync.go
@@ -1,0 +1,24 @@
+package search
+
+import "time"
+
+// SearchSyncJob is the outbox-style pending table for Elasticsearch sync.
+// Business writes enqueue a row; a background worker executes it with
+// exponential backoff, so per-item failures are retried instead of relying
+// only on startup ReindexAll.
+type SearchSyncJob struct {
+	ID          uint64     `gorm:"primaryKey"`
+	EntityType  string     `gorm:"size:16;not null;index"` // video | article | user
+	EntityID    uint64     `gorm:"not null;index"`
+	Action      string     `gorm:"size:8;not null"`                        // upsert | delete
+	Status      string     `gorm:"size:16;not null;default:pending;index"` // pending | done
+	Attempts    int        `gorm:"not null;default:0"`
+	NextRetryAt *time.Time `gorm:"index"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// TableName pins the name to the goose migration (migrations/00014).
+func (SearchSyncJob) TableName() string {
+	return "search_sync_outbox"
+}

--- a/internal/search/sync_job.go
+++ b/internal/search/sync_job.go
@@ -9,15 +9,22 @@ import (
 )
 
 const (
-	SyncJobEntityVideo   = "video"
+	// SyncJobEntityVideo identifies video documents.
+	SyncJobEntityVideo = "video"
+	// SyncJobEntityArticle identifies article documents.
 	SyncJobEntityArticle = "article"
-	SyncJobEntityUser    = "user"
+	// SyncJobEntityUser identifies user documents.
+	SyncJobEntityUser = "user"
 
+	// SyncJobActionUpsert indexes or replaces a document.
 	SyncJobActionUpsert = "upsert"
+	// SyncJobActionDelete removes a document.
 	SyncJobActionDelete = "delete"
 
+	// SyncJobStatusPending marks a job awaiting execution.
 	SyncJobStatusPending = "pending"
-	SyncJobStatusDone    = "done"
+	// SyncJobStatusDone marks a successfully executed job.
+	SyncJobStatusDone = "done"
 )
 
 // EnqueueSyncJob records a pending ES sync job. An existing pending row for
@@ -62,6 +69,7 @@ type ESClientExecutor struct {
 	DB     *gorm.DB
 }
 
+// Exec executes one sync job against the Elasticsearch client.
 func (e *ESClientExecutor) Exec(ctx context.Context, entityType string, entityID uint64, action string) error {
 	if e == nil || e.Client == nil || !e.Client.Enabled() {
 		return nil

--- a/internal/search/sync_job.go
+++ b/internal/search/sync_job.go
@@ -1,0 +1,132 @@
+package search
+
+import (
+	"context"
+	"time"
+
+	searchmodel "cakecake/internal/model/search"
+	"gorm.io/gorm"
+)
+
+const (
+	SyncJobEntityVideo   = "video"
+	SyncJobEntityArticle = "article"
+	SyncJobEntityUser    = "user"
+
+	SyncJobActionUpsert = "upsert"
+	SyncJobActionDelete = "delete"
+
+	SyncJobStatusPending = "pending"
+	SyncJobStatusDone    = "done"
+)
+
+// EnqueueSyncJob records a pending ES sync job. An existing pending row for
+// the same entity+action is reset (attempts=0, due immediately) instead of
+// duplicating it, so frequent updates collapse into one retryable job.
+func EnqueueSyncJob(ctx context.Context, db *gorm.DB, entityType string, entityID uint64, action string) error {
+	if db == nil {
+		return nil
+	}
+	now := time.Now()
+	var existing searchmodel.SearchSyncJob
+	err := db.WithContext(ctx).
+		Where("entity_type = ? AND entity_id = ? AND action = ? AND status = ?",
+			entityType, entityID, action, SyncJobStatusPending).
+		First(&existing).Error
+	if err == nil {
+		return db.Model(&existing).Updates(map[string]any{
+			"attempts":      0,
+			"next_retry_at": now,
+			"updated_at":    now,
+		}).Error
+	}
+	if err != gorm.ErrRecordNotFound {
+		return err
+	}
+	return db.WithContext(ctx).Create(&searchmodel.SearchSyncJob{
+		EntityType: entityType,
+		EntityID:   entityID,
+		Action:     action,
+		Status:     SyncJobStatusPending,
+	}).Error
+}
+
+// SyncExecutor executes one queued sync job.
+type SyncExecutor interface {
+	Exec(ctx context.Context, entityType string, entityID uint64, action string) error
+}
+
+// ESClientExecutor adapts the ES client + DB to SyncExecutor.
+type ESClientExecutor struct {
+	Client *Client
+	DB     *gorm.DB
+}
+
+func (e *ESClientExecutor) Exec(ctx context.Context, entityType string, entityID uint64, action string) error {
+	if e == nil || e.Client == nil || !e.Client.Enabled() {
+		return nil
+	}
+	switch entityType {
+	case SyncJobEntityVideo:
+		if action == SyncJobActionDelete {
+			return e.Client.DeleteVideo(ctx, entityID)
+		}
+		return e.Client.IndexVideoFromDB(ctx, e.DB, entityID)
+	case SyncJobEntityArticle:
+		if action == SyncJobActionDelete {
+			return e.Client.DeleteArticle(ctx, entityID)
+		}
+		return e.Client.IndexArticleFromDB(ctx, e.DB, entityID)
+	case SyncJobEntityUser:
+		// IndexUserFromDB removes docs for anonymized users, so a user
+		// "delete" is handled by upserting the anonymized row.
+		return e.Client.IndexUserFromDB(ctx, e.DB, entityID)
+	}
+	return nil
+}
+
+// ProcessDueSyncJobs runs one batch of due pending jobs: successes are marked
+// done, failures keep the row pending with exponential backoff. Returns the
+// number of rows handled.
+func ProcessDueSyncJobs(ctx context.Context, db *gorm.DB, exec SyncExecutor, batch int, now time.Time, backoff func(attempts int) time.Duration) (int, error) {
+	if db == nil || exec == nil {
+		return 0, nil
+	}
+	var rows []searchmodel.SearchSyncJob
+	if err := db.WithContext(ctx).
+		Where("status = ? AND (next_retry_at IS NULL OR next_retry_at <= ?)", SyncJobStatusPending, now).
+		Order("id ASC").
+		Limit(batch).
+		Find(&rows).Error; err != nil {
+		return 0, err
+	}
+	handled := 0
+	for i := range rows {
+		row := rows[i]
+		handled++
+		if err := exec.Exec(ctx, row.EntityType, row.EntityID, row.Action); err != nil {
+			attempts := row.Attempts + 1
+			next := now.Add(backoff(attempts))
+			_ = db.Model(&searchmodel.SearchSyncJob{}).
+				Where("id = ? AND status = ?", row.ID, SyncJobStatusPending).
+				Updates(map[string]any{"attempts": attempts, "next_retry_at": next}).Error
+			continue
+		}
+		_ = db.Model(&searchmodel.SearchSyncJob{}).
+			Where("id = ? AND status = ?", row.ID, SyncJobStatusPending).
+			Update("status", SyncJobStatusDone).Error
+	}
+	return handled, nil
+}
+
+// DefaultSyncBackoff is 10s doubling, capped at 5 minutes.
+func DefaultSyncBackoff(attempts int) time.Duration {
+	b := 10 * time.Second
+	for i := 1; i < attempts; i++ {
+		b *= 2
+		if b >= 5*time.Minute {
+			return 5 * time.Minute
+		}
+	}
+	return b
+}

--- a/internal/search/sync_job_test.go
+++ b/internal/search/sync_job_test.go
@@ -1,0 +1,105 @@
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	searchmodel "cakecake/internal/model/search"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func newSyncDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&searchmodel.SearchSyncJob{}))
+	return db
+}
+
+type fakeExec struct {
+	fail  bool
+	calls []string
+}
+
+func (f *fakeExec) Exec(_ context.Context, entityType string, entityID uint64, action string) error {
+	f.calls = append(f.calls, entityType+":"+action)
+	if f.fail {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+func TestEnqueueSyncJob_DedupeReset(t *testing.T) {
+	db := newSyncDB(t)
+	ctx := context.Background()
+	require.NoError(t, EnqueueSyncJob(ctx, db, SyncJobEntityVideo, 1, SyncJobActionUpsert))
+	require.NoError(t, EnqueueSyncJob(ctx, db, SyncJobEntityVideo, 1, SyncJobActionUpsert))
+
+	var rows []searchmodel.SearchSyncJob
+	require.NoError(t, db.Find(&rows).Error)
+	require.Len(t, rows, 1)
+
+	// Different action is a separate job.
+	require.NoError(t, EnqueueSyncJob(ctx, db, SyncJobEntityVideo, 1, SyncJobActionDelete))
+	require.NoError(t, db.Find(&rows).Error)
+	require.Len(t, rows, 2)
+}
+
+func TestProcessDueSyncJobs_Success(t *testing.T) {
+	db := newSyncDB(t)
+	ctx := context.Background()
+	require.NoError(t, EnqueueSyncJob(ctx, db, SyncJobEntityArticle, 7, SyncJobActionUpsert))
+
+	exec := &fakeExec{}
+	n, err := ProcessDueSyncJobs(ctx, db, exec, 10, time.Now(), DefaultSyncBackoff)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	require.Equal(t, []string{"article:upsert"}, exec.calls)
+
+	var row searchmodel.SearchSyncJob
+	require.NoError(t, db.First(&row).Error)
+	require.Equal(t, SyncJobStatusDone, row.Status)
+}
+
+func TestProcessDueSyncJobs_FailureBackoff(t *testing.T) {
+	db := newSyncDB(t)
+	ctx := context.Background()
+	require.NoError(t, EnqueueSyncJob(ctx, db, SyncJobEntityVideo, 3, SyncJobActionUpsert))
+
+	now := time.Now()
+	exec := &fakeExec{fail: true}
+	n, err := ProcessDueSyncJobs(ctx, db, exec, 10, now, DefaultSyncBackoff)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	var row searchmodel.SearchSyncJob
+	require.NoError(t, db.First(&row).Error)
+	require.Equal(t, SyncJobStatusPending, row.Status)
+	require.Equal(t, 1, row.Attempts)
+	require.NotNil(t, row.NextRetryAt)
+	require.True(t, row.NextRetryAt.After(now))
+
+	// Not due yet: second pass skips the row.
+	exec2 := &fakeExec{}
+	_, err = ProcessDueSyncJobs(ctx, db, exec2, 10, now.Add(2*time.Second), DefaultSyncBackoff)
+	require.NoError(t, err)
+	require.Empty(t, exec2.calls)
+}
+
+func TestProcessDueSyncJobs_OnlyDueRows(t *testing.T) {
+	db := newSyncDB(t)
+	ctx := context.Background()
+	require.NoError(t, EnqueueSyncJob(ctx, db, SyncJobEntityUser, 9, SyncJobActionUpsert))
+	future := time.Now().Add(time.Hour)
+	require.NoError(t, db.Model(&searchmodel.SearchSyncJob{}).
+		Where("entity_type = ?", SyncJobEntityUser).Update("next_retry_at", future).Error)
+
+	exec := &fakeExec{}
+	n, err := ProcessDueSyncJobs(ctx, db, exec, 10, time.Now(), DefaultSyncBackoff)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, exec.calls)
+}

--- a/internal/worker/search_sync_retry.go
+++ b/internal/worker/search_sync_retry.go
@@ -1,0 +1,41 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+
+	"cakecake/internal/search"
+)
+
+const (
+	searchSyncRetryInterval = 5 * time.Second
+	searchSyncRetryBatch    = 50
+)
+
+// StartSearchSyncRetry periodically executes pending Elasticsearch sync jobs
+// with exponential backoff (outbox-style per-item retry for ES sync).
+func StartSearchSyncRetry(ctx context.Context, db *gorm.DB, exec search.SyncExecutor, lg *zap.Logger) {
+	if db == nil || exec == nil {
+		return
+	}
+	t := time.NewTicker(searchSyncRetryInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			handled, err := search.ProcessDueSyncJobs(
+				ctx, db, exec, searchSyncRetryBatch, time.Now(), search.DefaultSyncBackoff)
+			if err != nil && lg != nil {
+				lg.Warn("search sync retry", zap.Error(err))
+			}
+			if handled > 0 && lg != nil {
+				lg.Debug("search sync retry handled", zap.Int("handled", handled))
+			}
+		}
+	}
+}

--- a/migrations/00014_search_sync_outbox.sql
+++ b/migrations/00014_search_sync_outbox.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS `search_sync_outbox` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `entity_type` varchar(16) NOT NULL,
+  `entity_id` bigint unsigned NOT NULL,
+  `action` varchar(8) NOT NULL,
+  `status` varchar(16) NOT NULL DEFAULT 'pending',
+  `attempts` bigint NOT NULL DEFAULT 0,
+  `next_retry_at` datetime(3) DEFAULT NULL,
+  `created_at` datetime(3) DEFAULT NULL,
+  `updated_at` datetime(3) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_search_sync_status_retry` (`status`,`next_retry_at`),
+  KEY `idx_search_sync_entity` (`entity_type`,`entity_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- +goose Down
+DROP TABLE IF EXISTS `search_sync_outbox`;


### PR DESCRIPTION
- add search_sync_outbox pending table (model + goose 00014 + GORM v32)
- handlers enqueue upsert/delete jobs instead of fire-and-forget goroutines
- worker retries due jobs every 5s with exponential backoff (10s base, 5min cap), marks done on success; startup ReindexAll remains the final fallback
- avatar/profile nuances preserved: avatar not re-indexed (enriched from MySQL at query time); user deletion handled via anonymized upsert
- tests for enqueue dedupe, success/failure backoff, due-row filtering